### PR TITLE
feat: configurable space-prefix search mode order with prefs UI

### DIFF
--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -8,6 +8,7 @@ except ImportError:
     from PySide2 import QtGui
 
 from tabtabtab_nuke_core import TabTabTabPlugin, launch
+import tabtabtab_prefs
 
 
 def _extract_node_class_from_script(script_text):
@@ -158,7 +159,14 @@ else:
 def registerNukeAction():
     menu = _getParentMenu()
     if menu.findItem("Tabtabtab") is None:
-        menu.addCommand("Tabtabtab", lambda: launch(_plugin), "Tab")
+        menu.addCommand(
+            "Tabtabtab",
+            lambda: launch(
+                _plugin,
+                space_mode_order=tabtabtab_prefs.prefs_singleton.get("space_mode_order"),
+            ),
+            "Tab",
+        )
 
 
 def unregisterNukeAction():

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -761,7 +761,9 @@ def launch(plugin, space_mode_order=None):
         try:
             # Update space mode order on reuse so pref changes take
             # effect without restarting the host application.
-            if space_mode_order is not None:
+            if (space_mode_order is not None
+                    and len(space_mode_order) == 3
+                    and all(m in VALID_MODES for m in space_mode_order)):
                 _tabtabtab_instance.things_model._space_mode_order = list(space_mode_order)
             _tabtabtab_instance.under_cursor()
             _tabtabtab_instance.show()

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -307,7 +307,7 @@ class NodeModel(QtCore.QAbstractListModel):
         self._color_fn = color_fn if color_fn is not None else (lambda obj: (None, None))
 
         if (space_mode_order is not None
-                and len(space_mode_order) == 3
+                and len(space_mode_order) == len(DEFAULT_SPACE_MODE_ORDER)
                 and all(m in VALID_MODES for m in space_mode_order)):
             self._space_mode_order = list(space_mode_order)
         else:
@@ -762,7 +762,7 @@ def launch(plugin, space_mode_order=None):
             # Update space mode order on reuse so pref changes take
             # effect without restarting the host application.
             if (space_mode_order is not None
-                    and len(space_mode_order) == 3
+                    and len(space_mode_order) == len(DEFAULT_SPACE_MODE_ORDER)
                     and all(m in VALID_MODES for m in space_mode_order)):
                 _tabtabtab_instance.things_model._space_mode_order = list(space_mode_order)
             _tabtabtab_instance.under_cursor()

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -17,6 +17,20 @@ except ImportError:
     from PySide2.QtCore import Qt
 
 
+# Search mode identifiers used by the space-prefix mapping preference.
+MODE_ANCHORED_FUZZY = "anchored_fuzzy"
+MODE_NON_ANCHORED_FUZZY = "non_anchored_fuzzy"
+MODE_CONSECUTIVE = "consecutive"
+
+VALID_MODES = {MODE_ANCHORED_FUZZY, MODE_NON_ANCHORED_FUZZY, MODE_CONSECUTIVE}
+
+DEFAULT_SPACE_MODE_ORDER = [
+    MODE_ANCHORED_FUZZY,       # 0 spaces (default)
+    MODE_NON_ANCHORED_FUZZY,   # 1 space
+    MODE_CONSECUTIVE,          # 2 spaces
+]
+
+
 class TabTabTabPlugin:
     def get_items(self):
         """Return list of {'menuobj': ..., 'menupath': str} dicts."""
@@ -281,7 +295,7 @@ class NodeWeights(object):
 
 
 class NodeModel(QtCore.QAbstractListModel):
-    def __init__(self, mlist, weights, num_items=18, filtertext="", icon_fn=None, color_fn=None):
+    def __init__(self, mlist, weights, num_items=18, filtertext="", icon_fn=None, color_fn=None, space_mode_order=None):
         super(NodeModel, self).__init__()
 
         self.weights = weights
@@ -291,6 +305,13 @@ class NodeModel(QtCore.QAbstractListModel):
         self._filtertext = filtertext
         self._icon_fn = icon_fn if icon_fn is not None else (lambda obj: None)
         self._color_fn = color_fn if color_fn is not None else (lambda obj: (None, None))
+
+        if (space_mode_order is not None
+                and len(space_mode_order) == 3
+                and all(m in VALID_MODES for m in space_mode_order)):
+            self._space_mode_order = list(space_mode_order)
+        else:
+            self._space_mode_order = list(DEFAULT_SPACE_MODE_ORDER)
 
         # _items is the list of objects to be shown, update sets this
         self._items = []
@@ -311,22 +332,34 @@ class NodeModel(QtCore.QAbstractListModel):
         force_non_anchored = False
         force_consecutive = False
 
-        # Two leading spaces: non-fuzzy (consecutive substring) search, non-anchored
+        # Determine space-prefix level (0, 1, or 2 leading spaces)
         if filtertext.startswith('  '):
-            anchored = False
-            force_consecutive = True
+            space_level = 2
             filtertext = filtertext[2:]
-        # One leading space: non-anchored fuzzy search
         elif filtertext.startswith(' '):
-            anchored = False
+            space_level = 1
             filtertext = filtertext[1:]
         # * or [ prefix: non-anchored fuzzy (legacy shortcuts, unchanged)
         elif filtertext.startswith('*') or filtertext.startswith('['):
+            space_level = None
             anchored = False
             filtertext = filtertext.replace("*", "", 1)
             if filtertext.startswith('*'):
                 force_non_anchored = True
             filtertext = filtertext.replace("*", "")
+        else:
+            space_level = 0
+
+        # Apply mode from the configurable space-prefix mapping
+        if space_level is not None:
+            mode = self._space_mode_order[space_level]
+            if mode == MODE_ANCHORED_FUZZY:
+                anchored = True
+            elif mode == MODE_NON_ANCHORED_FUZZY:
+                anchored = False
+            elif mode == MODE_CONSECUTIVE:
+                anchored = False
+                force_consecutive = True
 
         scored_a = []
         scored_b = []
@@ -525,7 +558,7 @@ class _ItemDelegate(QtWidgets.QStyledItemDelegate):
 
 
 class TabTabTabWidget(QtWidgets.QDialog):
-    def __init__(self, plugin, parent=None, winflags=None):
+    def __init__(self, plugin, parent=None, winflags=None, space_mode_order=None):
         super(TabTabTabWidget, self).__init__(parent=parent)
         if winflags is not None:
             self.setWindowFlags(winflags)
@@ -542,7 +575,7 @@ class TabTabTabWidget(QtWidgets.QDialog):
         items = plugin.get_items()
 
         # List of stuff, and associated model
-        self.things_model = NodeModel(items, weights=self.weights, icon_fn=plugin.get_icon, color_fn=plugin.get_color)
+        self.things_model = NodeModel(items, weights=self.weights, icon_fn=plugin.get_icon, color_fn=plugin.get_color, space_mode_order=space_mode_order)
         self.things = QtWidgets.QListView()
         self.things.setModel(self.things_model)
         self.things.setUniformItemSizes(True)
@@ -717,7 +750,7 @@ class TabTabTabWidget(QtWidgets.QDialog):
 _tabtabtab_instance = None
 
 
-def launch(plugin):
+def launch(plugin, space_mode_order=None):
     global _tabtabtab_instance
 
     if _tabtabtab_instance is not None:
@@ -726,6 +759,10 @@ def launch(plugin):
         # function and disappers instantly. This seems like a
         # reasonable "workaround"
         try:
+            # Update space mode order on reuse so pref changes take
+            # effect without restarting the host application.
+            if space_mode_order is not None:
+                _tabtabtab_instance.things_model._space_mode_order = list(space_mode_order)
             _tabtabtab_instance.under_cursor()
             _tabtabtab_instance.show()
             _tabtabtab_instance.raise_()
@@ -733,7 +770,7 @@ def launch(plugin):
         except ReferenceError:
             _tabtabtab_instance = None
 
-    t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint)
+    t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint, space_mode_order=space_mode_order)
 
     # Make dialog appear under cursor, as Nuke's builtin one does
     t.under_cursor()

--- a/tabtabtab_prefs.py
+++ b/tabtabtab_prefs.py
@@ -5,6 +5,7 @@ PREFS_FILE = os.path.join(os.path.expanduser("~"), ".nuke", "tabtabtab_prefs.jso
 
 DEFAULTS = {
     "tabtabtab_enabled": True,
+    "space_mode_order": ["anchored_fuzzy", "non_anchored_fuzzy", "consecutive"],
 }
 
 

--- a/tabtabtab_prefs_dialog.py
+++ b/tabtabtab_prefs_dialog.py
@@ -1,8 +1,11 @@
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QGroupBox,
+    QMessageBox,
     QVBoxLayout,
 )
 
@@ -29,6 +32,28 @@ class TabtabtabPrefsDialog(QDialog):
         )
         form_layout.addRow("Enable Tabtabtab:", self.tabtabtab_enabled_checkbox)
 
+        # Space-prefix mode mapping
+        mode_group = QGroupBox("Space-prefix search modes")
+        mode_layout = QFormLayout()
+        mode_group.setLayout(mode_layout)
+
+        mode_labels = {
+            "anchored_fuzzy": "Anchored fuzzy",
+            "non_anchored_fuzzy": "Non-anchored fuzzy",
+            "consecutive": "Consecutive substring",
+        }
+        all_modes = ["anchored_fuzzy", "non_anchored_fuzzy", "consecutive"]
+
+        self._space_combos = []
+        for space_label in ["No leading space:", "One leading space:", "Two leading spaces:"]:
+            combo = QComboBox()
+            for mode_id in all_modes:
+                combo.addItem(mode_labels[mode_id], mode_id)
+            mode_layout.addRow(space_label, combo)
+            self._space_combos.append(combo)
+
+        main_layout.addWidget(mode_group)
+
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         button_box.accepted.connect(self._on_accept)
         button_box.rejected.connect(self.reject)
@@ -38,10 +63,27 @@ class TabtabtabPrefsDialog(QDialog):
         prefs = tabtabtab_prefs.prefs_singleton
         self.tabtabtab_enabled_checkbox.setChecked(bool(prefs.get("tabtabtab_enabled")))
 
+        space_mode_order = prefs.get("space_mode_order")
+        for i, combo in enumerate(self._space_combos):
+            idx = combo.findData(space_mode_order[i])
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+
     def _on_accept(self):
         prefs = tabtabtab_prefs.prefs_singleton
+
+        space_mode_order = [combo.currentData() for combo in self._space_combos]
+        if len(set(space_mode_order)) < 3:
+            QMessageBox.warning(
+                self,
+                "Invalid configuration",
+                "Each search mode must be assigned to exactly one space level.",
+            )
+            return
+
         enabled = self.tabtabtab_enabled_checkbox.isChecked()
         prefs.set("tabtabtab_enabled", enabled)
+        prefs.set("space_mode_order", space_mode_order)
         prefs.save()
         if enabled:
             tabtabtab_nuke.registerNukeAction()

--- a/tabtabtab_prefs_dialog.py
+++ b/tabtabtab_prefs_dialog.py
@@ -1,15 +1,28 @@
-from PySide6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QGroupBox,
-    QMessageBox,
-    QVBoxLayout,
-)
+try:
+    from PySide6.QtWidgets import (
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QDialogButtonBox,
+        QFormLayout,
+        QGroupBox,
+        QMessageBox,
+        QVBoxLayout,
+    )
+except ImportError:
+    from PySide2.QtWidgets import (
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QDialogButtonBox,
+        QFormLayout,
+        QGroupBox,
+        QMessageBox,
+        QVBoxLayout,
+    )
 
 import tabtabtab_nuke
+import tabtabtab_nuke_core
 import tabtabtab_prefs
 
 
@@ -38,11 +51,11 @@ class TabtabtabPrefsDialog(QDialog):
         mode_group.setLayout(mode_layout)
 
         mode_labels = {
-            "anchored_fuzzy": "Anchored fuzzy",
-            "non_anchored_fuzzy": "Non-anchored fuzzy",
-            "consecutive": "Consecutive substring",
+            tabtabtab_nuke_core.MODE_ANCHORED_FUZZY: "Anchored fuzzy",
+            tabtabtab_nuke_core.MODE_NON_ANCHORED_FUZZY: "Non-anchored fuzzy",
+            tabtabtab_nuke_core.MODE_CONSECUTIVE: "Consecutive substring",
         }
-        all_modes = ["anchored_fuzzy", "non_anchored_fuzzy", "consecutive"]
+        all_modes = list(tabtabtab_nuke_core.DEFAULT_SPACE_MODE_ORDER)
 
         self._space_combos = []
         for space_label in ["No leading space:", "One leading space:", "Two leading spaces:"]:


### PR DESCRIPTION
## Summary

- Syncs `tabtabtab_nuke_core.py` with the canonical core to add the `space_mode_order` parameter
- `tabtabtab_nuke.py` reads `space_mode_order` from `tabtabtab_prefs.prefs_singleton` and passes it to `launch()` on every invocation
- `tabtabtab_prefs.py` adds `"space_mode_order"` to `DEFAULTS` (preserving existing default behaviour)
- `tabtabtab_prefs_dialog.py` adds a "Space-prefix search modes" group box with three combo boxes; saving validates that all three modes are distinct before writing

## Test plan

- [ ] Open prefs dialog — confirm "Space-prefix search modes" group box appears with three combos pre-populated from saved prefs
- [ ] Change a mode, save — confirm the new mapping is active immediately without restarting Nuke
- [ ] Try to save with two combos set to the same mode — confirm warning dialog blocks the save
- [ ] Confirm default search behaviour is unchanged for a fresh install (no existing prefs file)