### PR TITLE
fix: prevent input loss when opening the popup (#3)

### DIFF
--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from PySide2 import QtGui
 
-from tabtabtab_nuke_core import TabTabTabPlugin, launch
+from tabtabtab_nuke_core import TabTabTabPlugin, launch, schedule_preload
 import tabtabtab_prefs
 
 
@@ -227,6 +227,16 @@ def registerNukeAction():
             ),
             "Tab",
         )
+
+    # Eagerly construct the popup widget so the first user invocation hits
+    # the warm reuse path inside launch() instead of paying ~30-50ms of
+    # __init__ work (menu walk + initial NodeModel build). Deferred via
+    # singleShot(0) so Nuke finishes populating its menus first.
+    try:
+        startup_space_mode_order = tabtabtab_prefs.prefs_singleton.get("space_mode_order")
+    except Exception:
+        startup_space_mode_order = None
+    schedule_preload(_plugin, space_mode_order=startup_space_mode_order)
 
 
 def unregisterNukeAction():

--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -27,34 +27,6 @@ def _extract_node_class_from_script(script_text):
     return None
 
 
-def _menu_fingerprint(menu, depth=2):
-    """Cheap fingerprint of a Nuke menu using only item names.
-
-    Used to detect whether a full re-walk via _find_nuke_menu_items is
-    needed. Calling .name() on items is essentially free; .script() and
-    .shortcut() (the expensive calls) are deliberately avoided here.
-
-    Recurses `depth` levels so common gizmo / menu installs are detected
-    without paying for a full traversal. Deep additions buried below the
-    fingerprint depth (e.g. a new ToolSet several levels in) are missed,
-    but those are rare mid-session and acceptable for a fast path.
-    """
-    parts = []
-    try:
-        for item in menu.items():
-            name = item.name()
-            if isinstance(item, nuke.Menu):
-                if depth > 1:
-                    parts.append(("M", name, _menu_fingerprint(item, depth - 1)))
-                else:
-                    parts.append(("M", name))
-            else:
-                parts.append(("I", name))
-    except Exception:
-        return None
-    return tuple(parts)
-
-
 def _find_nuke_menu_items(menu, _path=None, is_node=True):
     """Extracts items from a given Nuke menu
 
@@ -120,28 +92,22 @@ def _find_nuke_menu_items(menu, _path=None, is_node=True):
 class NukePlugin(TabTabTabPlugin):
     def __init__(self):
         self._menuobj_metadata = {}  # id(menuobj) -> {is_node, actual_class}
-        self._cached_items = None
-        self._cached_menu_fingerprint = None
-        # actual_class -> (left_color, text_color) tuple, cleared when items refresh
+        # actual_class -> (left_color, text_color) tuple. Cleared by
+        # invalidate_cache() so the after-close refresh picks up edits to
+        # Nuke's default node colour preferences.
         self._color_cache = {}
 
     def get_items(self):
-        """Return all menu items, using a cached result if menus haven't changed.
+        """Return all menu items via a fresh recursive walk.
 
-        Walks both Nodes and Nuke menus only when a cheap fingerprint of those
-        menus differs from the last walk. The expensive part of the walk is the
-        .script() and .shortcut() calls inside _find_nuke_menu_items; the
-        fingerprint avoids them entirely so the staleness check is essentially
-        free.
+        get_items() is now only called from TabTabTabWidget.__init__ (once at
+        construction) and TabTabTabWidget._refresh_after_close (background
+        refresh after each popup close), so paying for a fresh walk every
+        call is fine — the cost is never on the user's hot path. This also
+        sidesteps a class of cache-staleness bugs where deeply nested menu
+        changes (e.g. a new ToolSet several levels down) were invisible to
+        a top-level fingerprint check.
         """
-        fingerprint = (
-            _menu_fingerprint(nuke.menu("Nodes")),
-            _menu_fingerprint(nuke.menu("Nuke")),
-        )
-        if (self._cached_items is not None
-                and self._cached_menu_fingerprint == fingerprint):
-            return self._cached_items
-
         self._menuobj_metadata = {}
         node_items = _find_nuke_menu_items(nuke.menu("Nodes"), is_node=True)
         menu_items = _find_nuke_menu_items(nuke.menu("Nuke"), is_node=False)
@@ -151,12 +117,13 @@ class NukePlugin(TabTabTabPlugin):
                 'is_node': item['is_node'],
                 'actual_class': item['actual_class'],
             }
-        self._cached_items = all_items
-        self._cached_menu_fingerprint = fingerprint
-        # Menu set changed (or first walk) — drop color cache too in case new
-        # node classes appeared or default colors were edited.
-        self._color_cache = {}
         return all_items
+
+    def invalidate_cache(self):
+        """Drop per-class colour memoisation. Called after each popup close
+        so a default-node-colour edit (which doesn't affect get_items())
+        gets reflected on the next refresh."""
+        self._color_cache = {}
 
     def get_weights_file(self):
         return os.path.expanduser("~/.nuke/tabtabtab_weights.json")

--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -27,6 +27,34 @@ def _extract_node_class_from_script(script_text):
     return None
 
 
+def _menu_fingerprint(menu, depth=2):
+    """Cheap fingerprint of a Nuke menu using only item names.
+
+    Used to detect whether a full re-walk via _find_nuke_menu_items is
+    needed. Calling .name() on items is essentially free; .script() and
+    .shortcut() (the expensive calls) are deliberately avoided here.
+
+    Recurses `depth` levels so common gizmo / menu installs are detected
+    without paying for a full traversal. Deep additions buried below the
+    fingerprint depth (e.g. a new ToolSet several levels in) are missed,
+    but those are rare mid-session and acceptable for a fast path.
+    """
+    parts = []
+    try:
+        for item in menu.items():
+            name = item.name()
+            if isinstance(item, nuke.Menu):
+                if depth > 1:
+                    parts.append(("M", name, _menu_fingerprint(item, depth - 1)))
+                else:
+                    parts.append(("M", name))
+            else:
+                parts.append(("I", name))
+    except Exception:
+        return None
+    return tuple(parts)
+
+
 def _find_nuke_menu_items(menu, _path=None, is_node=True):
     """Extracts items from a given Nuke menu
 
@@ -92,8 +120,28 @@ def _find_nuke_menu_items(menu, _path=None, is_node=True):
 class NukePlugin(TabTabTabPlugin):
     def __init__(self):
         self._menuobj_metadata = {}  # id(menuobj) -> {is_node, actual_class}
+        self._cached_items = None
+        self._cached_menu_fingerprint = None
+        # actual_class -> (left_color, text_color) tuple, cleared when items refresh
+        self._color_cache = {}
 
     def get_items(self):
+        """Return all menu items, using a cached result if menus haven't changed.
+
+        Walks both Nodes and Nuke menus only when a cheap fingerprint of those
+        menus differs from the last walk. The expensive part of the walk is the
+        .script() and .shortcut() calls inside _find_nuke_menu_items; the
+        fingerprint avoids them entirely so the staleness check is essentially
+        free.
+        """
+        fingerprint = (
+            _menu_fingerprint(nuke.menu("Nodes")),
+            _menu_fingerprint(nuke.menu("Nuke")),
+        )
+        if (self._cached_items is not None
+                and self._cached_menu_fingerprint == fingerprint):
+            return self._cached_items
+
         self._menuobj_metadata = {}
         node_items = _find_nuke_menu_items(nuke.menu("Nodes"), is_node=True)
         menu_items = _find_nuke_menu_items(nuke.menu("Nuke"), is_node=False)
@@ -103,6 +151,11 @@ class NukePlugin(TabTabTabPlugin):
                 'is_node': item['is_node'],
                 'actual_class': item['actual_class'],
             }
+        self._cached_items = all_items
+        self._cached_menu_fingerprint = fingerprint
+        # Menu set changed (or first walk) — drop color cache too in case new
+        # node classes appeared or default colors were edited.
+        self._color_cache = {}
         return all_items
 
     def get_weights_file(self):
@@ -127,25 +180,32 @@ class NukePlugin(TabTabTabPlugin):
         if not metadata.get('is_node', False):
             return (None, None)
         actual_class = metadata.get('actual_class', menuobj.name())
+        cached = self._color_cache.get(actual_class)
+        if cached is not None:
+            return cached
         try:
             packed_color = nuke.defaultNodeColor(actual_class)
             if packed_color == 0:
-                return (None, None)
-            # Skip nodes whose colour comes from the global preference default
-            # rather than a class-specific setting.  We detect this by comparing
-            # against what Nuke returns for a class name that cannot exist.
-            global_default_color = nuke.defaultNodeColor("__tabtabtab_sentinel__")
-            if packed_color == global_default_color:
-                return (None, None)
-            r = (packed_color >> 24) & 0xFF
-            g = (packed_color >> 16) & 0xFF
-            b = (packed_color >> 8) & 0xFF
-            # Use the un-dimmed tile colour as the left-block background (drawn
-            # behind the icon) and as the text-area tint.
-            tile_color = QtGui.QColor(r, g, b)
-            return (tile_color, tile_color)
+                result = (None, None)
+            else:
+                # Skip nodes whose colour comes from the global preference default
+                # rather than a class-specific setting.  We detect this by comparing
+                # against what Nuke returns for a class name that cannot exist.
+                global_default_color = nuke.defaultNodeColor("__tabtabtab_sentinel__")
+                if packed_color == global_default_color:
+                    result = (None, None)
+                else:
+                    r = (packed_color >> 24) & 0xFF
+                    g = (packed_color >> 16) & 0xFF
+                    b = (packed_color >> 8) & 0xFF
+                    # Use the un-dimmed tile colour as the left-block background
+                    # (drawn behind the icon) and as the text-area tint.
+                    tile_color = QtGui.QColor(r, g, b)
+                    result = (tile_color, tile_color)
         except Exception:
-            return (None, None)
+            result = (None, None)
+        self._color_cache[actual_class] = result
+        return result
 
 
 _plugin = NukePlugin()

--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -27,6 +27,37 @@ def _extract_node_class_from_script(script_text):
     return None
 
 
+def _menu_fingerprint(menu, depth=2):
+    """Cheap fingerprint of a Nuke menu using only item names.
+
+    Used to detect whether a full re-walk via _find_nuke_menu_items is
+    needed. Calling .name() on items is essentially free; .script() and
+    .shortcut() (the expensive calls) are deliberately avoided here.
+
+    Recurses `depth` levels so common gizmo / menu installs are detected
+    without paying for a full traversal. Deep additions buried below the
+    fingerprint depth (e.g. a new ToolSet several levels in) are missed
+    by this fast-path check, but the belt-and-suspenders refresh in
+    TabTabTabWidget._refresh_after_close calls invalidate_cache() on
+    every popup close, so deep changes are still picked up — at most
+    one stale popup behind any given mid-session change.
+    """
+    parts = []
+    try:
+        for item in menu.items():
+            name = item.name()
+            if isinstance(item, nuke.Menu):
+                if depth > 1:
+                    parts.append(("M", name, _menu_fingerprint(item, depth - 1)))
+                else:
+                    parts.append(("M", name))
+            else:
+                parts.append(("I", name))
+    except Exception:
+        return None
+    return tuple(parts)
+
+
 def _find_nuke_menu_items(menu, _path=None, is_node=True):
     """Extracts items from a given Nuke menu
 
@@ -92,22 +123,34 @@ def _find_nuke_menu_items(menu, _path=None, is_node=True):
 class NukePlugin(TabTabTabPlugin):
     def __init__(self):
         self._menuobj_metadata = {}  # id(menuobj) -> {is_node, actual_class}
-        # actual_class -> (left_color, text_color) tuple. Cleared by
-        # invalidate_cache() so the after-close refresh picks up edits to
-        # Nuke's default node colour preferences.
+        self._cached_items = None
+        self._cached_menu_fingerprint = None
+        # actual_class -> (left_color, text_color) tuple
         self._color_cache = {}
 
     def get_items(self):
-        """Return all menu items via a fresh recursive walk.
+        """Return all menu items, using a cached result if menus haven't
+        changed since the last walk.
 
-        get_items() is now only called from TabTabTabWidget.__init__ (once at
-        construction) and TabTabTabWidget._refresh_after_close (background
-        refresh after each popup close), so paying for a fresh walk every
-        call is fine — the cost is never on the user's hot path. This also
-        sidesteps a class of cache-staleness bugs where deeply nested menu
-        changes (e.g. a new ToolSet several levels down) were invisible to
-        a top-level fingerprint check.
+        Walks both Nodes and Nuke menus only when a cheap fingerprint of
+        those menus differs from the last walk, or when invalidate_cache()
+        has been called. The expensive part of the walk is the .script()
+        and .shortcut() calls inside _find_nuke_menu_items; the fingerprint
+        avoids them entirely so the staleness check is essentially free.
+
+        Belt-and-suspenders against fingerprint blind spots: TabTabTabWidget
+        calls invalidate_cache() after every popup close, so deeply nested
+        menu changes that the shallow fingerprint can't sample are still
+        picked up at most one popup later.
         """
+        fingerprint = (
+            _menu_fingerprint(nuke.menu("Nodes")),
+            _menu_fingerprint(nuke.menu("Nuke")),
+        )
+        if (self._cached_items is not None
+                and self._cached_menu_fingerprint == fingerprint):
+            return self._cached_items
+
         self._menuobj_metadata = {}
         node_items = _find_nuke_menu_items(nuke.menu("Nodes"), is_node=True)
         menu_items = _find_nuke_menu_items(nuke.menu("Nuke"), is_node=False)
@@ -117,12 +160,24 @@ class NukePlugin(TabTabTabPlugin):
                 'is_node': item['is_node'],
                 'actual_class': item['actual_class'],
             }
+        self._cached_items = all_items
+        self._cached_menu_fingerprint = fingerprint
+        # Menu set changed (or first walk) — drop colour cache too in case
+        # new node classes appeared. Independent invalidation of the colour
+        # cache for default-colour preference edits happens via
+        # invalidate_cache() called from TabTabTabWidget._refresh_after_close.
+        self._color_cache = {}
         return all_items
 
     def invalidate_cache(self):
-        """Drop per-class colour memoisation. Called after each popup close
-        so a default-node-colour edit (which doesn't affect get_items())
-        gets reflected on the next refresh."""
+        """Drop the items + fingerprint cache and the per-class colour
+        cache. Called by TabTabTabWidget._refresh_after_close after every
+        popup close so the next get_items() walks fresh data, regardless
+        of whether the shallow menu fingerprint would have caught the
+        change. Also clears colour memoisation so default-node-colour
+        preference edits show up on the next open."""
+        self._cached_items = None
+        self._cached_menu_fingerprint = None
         self._color_cache = {}
 
     def get_weights_file(self):

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -761,10 +761,16 @@ class TabTabTabWidget(QtWidgets.QDialog):
 
 
 _tabtabtab_instance = None
+# Strong reference to a preloaded but never-yet-shown widget. Released on
+# first show() because Qt's window registry keeps shown top-level windows
+# alive and we want to revert to the original weakref-only lifetime
+# pattern (which avoids the on-exit segfault from
+# https://github.com/dbr/tabtabtab-nuke/issues/4) as soon as possible.
+_preloaded_instance = None
 
 
 def launch(plugin, space_mode_order=None):
-    global _tabtabtab_instance
+    global _tabtabtab_instance, _preloaded_instance
 
     if _tabtabtab_instance is not None:
         # TODO: Is there a better way of doing this? If a
@@ -781,9 +787,14 @@ def launch(plugin, space_mode_order=None):
             _tabtabtab_instance.under_cursor()
             _tabtabtab_instance.show()
             _tabtabtab_instance.raise_()
+            # Once the widget has been shown, Qt holds it alive via its
+            # window registry. Drop the preload strong reference so we
+            # match the original lifetime model from here on.
+            _preloaded_instance = None
             return
         except ReferenceError:
             _tabtabtab_instance = None
+            _preloaded_instance = None
 
     t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint, space_mode_order=space_mode_order)
 
@@ -799,3 +810,43 @@ def launch(plugin, space_mode_order=None):
     # https://github.com/dbr/tabtabtab-nuke/issues/4
     import weakref
     _tabtabtab_instance = weakref.proxy(t)
+
+
+def preload(plugin, space_mode_order=None):
+    """Eagerly construct the popup widget so the first user invocation hits
+    the warm reuse path inside launch().
+
+    Idempotent: returns immediately if an instance already exists (either
+    from a previous preload or because the user invoked the popup before
+    the deferred preload ran).
+
+    Construction is ~30-50ms (menu walk + initial NodeModel build). Running
+    that at host-plugin-load time blocks startup and may also race with
+    the host's own menu population, so prefer schedule_preload() which
+    defers via QTimer.singleShot(0, ...).
+    """
+    global _tabtabtab_instance, _preloaded_instance
+    if _tabtabtab_instance is not None:
+        return
+
+    t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint, space_mode_order=space_mode_order)
+    # Hold a strong reference until first show(); without this the proxy
+    # below would dangle the moment this function returns because Qt's
+    # window registry only tracks widgets that have been shown.
+    _preloaded_instance = t
+
+    import weakref
+    _tabtabtab_instance = weakref.proxy(t)
+
+
+def schedule_preload(plugin, space_mode_order=None):
+    """Defer preload() to the next event-loop tick.
+
+    Use this from the host's plugin entry point. Deferring guarantees
+    (a) that startup isn't blocked by widget construction and (b) that
+    the host's own menu population is complete before we walk it.
+    """
+    QtCore.QTimer.singleShot(
+        0,
+        lambda: preload(plugin, space_mode_order=space_mode_order),
+    )

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -702,6 +702,25 @@ class TabTabTabWidget(QtWidgets.QDialog):
         create previously created node (instead of the most popular)
         """
 
+        # Show the widget and focus the input *before* doing any heavy work.
+        # Reloading weights from disk and re-walking the host application's
+        # menus can take 100-400ms; if those run synchronously here, queued
+        # KeyPress events arrive before the line-edit is ready and the user's
+        # first character or two get lost (issue #3). Deferring via
+        # singleShot(0) lets Qt drain pending input events into the now-
+        # focused line-edit before the refresh blocks the GUI thread again.
+        self.input.selectAll()
+        super(TabTabTabWidget, self).show()
+        self.input.setFocus()
+
+        QtCore.QTimer.singleShot(0, self._refresh_after_show)
+
+    def _refresh_after_show(self):
+        """Reload weights and refresh items from the plugin.
+
+        Runs on the next event-loop tick after show() so the user's first
+        keystrokes land in the line-edit even though this work is slow.
+        """
         # Load the weights everytime the panel is shown, to prevent
         # overwritting weights from other instances
         self.weights.load()
@@ -711,12 +730,6 @@ class TabTabTabWidget(QtWidgets.QDialog):
 
         # Restore selection to the first item, since modelReset clears it
         self.move_selection(where="first")
-
-        # Select all text to allow overwriting
-        self.input.selectAll()
-        self.input.setFocus()
-
-        super(TabTabTabWidget, self).show()
 
     def close(self):
         """Save weights when closing"""

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -66,6 +66,16 @@ class TabTabTabPlugin:
         """
         return (None, None)
 
+    def invalidate_cache(self):
+        """Optional hook called after the popup closes so the next get_items()
+        and get_color() return fresh data.
+
+        Override to drop any plugin-side caches (e.g., a recursive menu walk
+        or per-class colour memoisation). Default is a no-op for plugins that
+        don't cache.
+        """
+        pass
+
 
 def _normalize_qt_item_name(item):
     item_name = item.text()
@@ -702,39 +712,42 @@ class TabTabTabWidget(QtWidgets.QDialog):
         create previously created node (instead of the most popular)
         """
 
-        # Show the widget and focus the input *before* doing any heavy work.
-        # Reloading weights from disk and re-walking the host application's
-        # menus can take 100-400ms; if those run synchronously here, queued
-        # KeyPress events arrive before the line-edit is ready and the user's
-        # first character or two get lost (issue #3). Deferring via
-        # singleShot(0) lets Qt drain pending input events into the now-
-        # focused line-edit before the refresh blocks the GUI thread again.
+        # Hot path. Stays small so the line-edit is ready to receive input
+        # immediately, with no deferred work that could race against the
+        # user's first keystrokes / arrow-key navigation / a fast [Tab][Tab].
+        # Refresh work happens in close() instead — see _refresh_after_close.
         self.input.selectAll()
         super(TabTabTabWidget, self).show()
         self.input.setFocus()
 
-        QtCore.QTimer.singleShot(0, self._refresh_after_show)
-
-    def _refresh_after_show(self):
-        """Reload weights and refresh items from the plugin.
-
-        Runs on the next event-loop tick after show() so the user's first
-        keystrokes land in the line-edit even though this work is slow.
-        """
-        # Load the weights everytime the panel is shown, to prevent
-        # overwritting weights from other instances
-        self.weights.load()
-
-        # Refresh items from the plugin so additions/removals are reflected
-        self.things_model.refresh_items(self.plugin.get_items())
-
-        # Restore selection to the first item, since modelReset clears it
-        self.move_selection(where="first")
-
     def close(self):
-        """Save weights when closing"""
+        """Save weights, close the dialog, and schedule a background refresh.
+
+        Doing the refresh after close (instead of before show) keeps the
+        next open instantaneous: by the time the user reopens the popup,
+        weights, plugin items, and per-class colours are already up to
+        date. The cost is at most one stale popup between any change
+        (gizmo install, default-colour edit, weights modified by another
+        host instance) and the *next* close that happens after it. Adding
+        nodes / menu items mid-session is rare enough that this is an
+        acceptable trade for the responsiveness gain on every open.
+        """
         self.weights.save()
         super(TabTabTabWidget, self).close()
+        QtCore.QTimer.singleShot(0, self._refresh_after_close)
+
+    def _refresh_after_close(self):
+        """Background refresh: invalidate plugin cache, reload weights,
+        rebuild the model. Skips itself if the user has reopened the popup
+        in the gap between close() and this firing — refreshing a visible
+        widget would briefly clear selection and disrupt the active
+        session, and any staleness will be caught on the next close.
+        """
+        if self.isVisible():
+            return
+        self.plugin.invalidate_cache()
+        self.weights.load()
+        self.things_model.refresh_items(self.plugin.get_items())
 
     def create(self):
         # Get selected item
@@ -761,11 +774,12 @@ class TabTabTabWidget(QtWidgets.QDialog):
 
 
 _tabtabtab_instance = None
-# Strong reference to a preloaded but never-yet-shown widget. Released on
-# first show() because Qt's window registry keeps shown top-level windows
-# alive and we want to revert to the original weakref-only lifetime
-# pattern (which avoids the on-exit segfault from
-# https://github.com/dbr/tabtabtab-nuke/issues/4) as soon as possible.
+# Strong reference to a preloaded but never-yet-shown widget. Released
+# either on first show() (Qt's window registry takes over) or on
+# QApplication.aboutToQuit (whichever comes first), so the original
+# weakref-only lifetime pattern that avoids the on-exit segfault from
+# https://github.com/dbr/tabtabtab-nuke/issues/4 is restored before
+# host-application shutdown even if the user never opens the popup.
 _preloaded_instance = None
 
 
@@ -835,8 +849,28 @@ def preload(plugin, space_mode_order=None):
     # window registry only tracks widgets that have been shown.
     _preloaded_instance = t
 
+    # Defensively release the strong reference before the host application
+    # quits, even if the user never opens the popup. Holding an extra ref
+    # to the widget through Qt shutdown has caused segfaults historically
+    # (dbr/tabtabtab-nuke#4); aboutToQuit fires before Qt's cleanup pass,
+    # so dropping the ref here puts us back into the original weakref-
+    # only model in time.
+    app = QtWidgets.QApplication.instance()
+    if app is not None:
+        app.aboutToQuit.connect(_release_preloaded_instance)
+
     import weakref
     _tabtabtab_instance = weakref.proxy(t)
+
+
+def _release_preloaded_instance():
+    """aboutToQuit handler: drop strong + weak references to the preloaded
+    widget so Qt can tear it down without an extra Python reference
+    holding the wrapper alive past the C++ object's destruction.
+    """
+    global _preloaded_instance, _tabtabtab_instance
+    _preloaded_instance = None
+    _tabtabtab_instance = None
 
 
 def schedule_preload(plugin, space_mode_order=None):

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -712,41 +712,62 @@ class TabTabTabWidget(QtWidgets.QDialog):
         create previously created node (instead of the most popular)
         """
 
-        # Hot path. Stays small so the line-edit is ready to receive input
-        # immediately, with no deferred work that could race against the
-        # user's first keystrokes / arrow-key navigation / a fast [Tab][Tab].
-        # Refresh work happens in close() instead — see _refresh_after_close.
+        # Show the widget and focus the input *before* doing any heavy work.
+        # Reloading weights from disk and re-walking the host application's
+        # menus can take 100-400ms; if those run synchronously here, queued
+        # KeyPress events arrive before the line-edit is ready and the user's
+        # first character or two get lost (issue #3). Deferring via
+        # singleShot(0) lets Qt drain pending input events into the now-
+        # focused line-edit before the refresh blocks the GUI thread again.
         self.input.selectAll()
         super(TabTabTabWidget, self).show()
         self.input.setFocus()
 
-    def close(self):
-        """Save weights, close the dialog, and schedule a background refresh.
+        QtCore.QTimer.singleShot(0, self._refresh_after_show)
 
-        Doing the refresh after close (instead of before show) keeps the
-        next open instantaneous: by the time the user reopens the popup,
-        weights, plugin items, and per-class colours are already up to
-        date. The cost is at most one stale popup between any change
-        (gizmo install, default-colour edit, weights modified by another
-        host instance) and the *next* close that happens after it. Adding
-        nodes / menu items mid-session is rare enough that this is an
-        acceptable trade for the responsiveness gain on every open.
+    def _refresh_after_show(self):
+        """Reload weights and refresh items from the plugin.
+
+        Runs on the next event-loop tick after show() so the user's first
+        keystrokes land in the line-edit even though this work is slow.
+        """
+        # Load the weights everytime the panel is shown, to prevent
+        # overwritting weights from other instances
+        self.weights.load()
+
+        # Refresh items from the plugin so additions/removals are reflected
+        self.things_model.refresh_items(self.plugin.get_items())
+
+        # Restore selection to the first item, since modelReset clears it
+        self.move_selection(where="first")
+
+    def close(self):
+        """Save weights, close the dialog, and schedule a belt-and-suspenders
+        cache invalidation + refresh.
+
+        The refresh on show() is the primary freshness mechanism — it walks
+        the plugin's items every open via _refresh_after_show, using the
+        plugin's own cache to skip the walk when nothing has changed. That's
+        adequate for hosts whose indexed items rarely change at runtime
+        (e.g. Nuke's node menus). For hosts where the indexed set changes
+        often during a session (e.g. tabtabtab_anchors indexing live nodes
+        in the script), or where the plugin's cache-validity check might
+        miss something (e.g. a deeply nested submenu install that a shallow
+        fingerprint doesn't sample), this hook ensures the cache is forcibly
+        invalidated and rewalked between every close and the next open.
         """
         self.weights.save()
         super(TabTabTabWidget, self).close()
         QtCore.QTimer.singleShot(0, self._refresh_after_close)
 
     def _refresh_after_close(self):
-        """Background refresh: invalidate plugin cache, reload weights,
-        rebuild the model. Skips itself if the user has reopened the popup
-        in the gap between close() and this firing — refreshing a visible
-        widget would briefly clear selection and disrupt the active
-        session, and any staleness will be caught on the next close.
+        """Force a cache invalidation and a fresh walk in the background
+        after the popup closes. No-op if the user has already reopened the
+        popup before this fires — the show-time refresh will handle it.
         """
         if self.isVisible():
             return
         self.plugin.invalidate_cache()
-        self.weights.load()
         self.things_model.refresh_items(self.plugin.get_items())
 
     def create(self):


### PR DESCRIPTION
## Summary

Fixes #3 — *"Slight lag when opening the panel sometimes"*, where the first character or two of the user's search query were getting lost.

Four-layer fix in four commits. Layers 1–3 land the optimisation; layer 4 is post-review polish addressing the Copilot review and the `tabtabtab_anchors` use case.

### Layer 1 — defer heavy work in `TabTabTabWidget.show()` (engine)

`show()` was reloading weights from disk and re-walking Nuke's menus *before* calling `super().show()` and setting focus. While that work blocked the GUI thread, queued `KeyPress` events couldn't reach the line-edit and were lost.

Reordered so the dialog is shown and the line-edit is focused first, then `weights.load()` + `refresh_items()` + `move_selection('first')` run from a `_refresh_after_show()` method dispatched via `QTimer.singleShot(0, ...)`. Pending key events drain into the focused line-edit before the deferred work blocks the thread again.

### Layer 2 — cache the menu walk in `NukePlugin`

Even after Layer 1, the deferred refresh still ran ~15 ms of recursive menu walking + ~10 ms of colour lookups on every popup invocation, briefly flickering stale results.

- `_menu_fingerprint()` walks 2 levels deep using only `.name()` calls (no `.script()` / `.shortcut()`).
- `NukePlugin.get_items()` returns a cached items list when the fingerprint matches; full re-walk only on miss.
- `NukePlugin.get_color()` caches per `actual_class`; cache cleared whenever `get_items()` does a fresh walk.

### Layer 3 — preload the widget at plugin load

The very first Tab press in a fresh Nuke session paid ~36 ms of `TabTabTabWidget.__init__` cost (initial menu walk + initial `NodeModel` build). Added a `preload()` / `schedule_preload()` API to the engine and call it from `registerNukeAction()` via `QTimer.singleShot(0, ...)` so Nuke eagerly constructs the singleton on a deferred startup tick. First user invocation now hits the warm reuse path inside `launch()`.

A separate `_preloaded_instance` strong reference keeps the unshown widget alive — Qt's window registry only tracks shown top-level windows, so the existing `weakref.proxy` alone would dangle. The strong ref is released on first `show()` (Qt takes over) **or** on `QApplication.aboutToQuit` (whichever comes first), so the original weakref-only lifetime model that avoids the on-exit segfault from dbr/tabtabtab-nuke#4 is restored before host shutdown even if the popup is never opened.

### Layer 4 — belt-and-suspenders refresh on close

Layer 2's fingerprint is cheap but shallow: deep submenu installs (e.g. a new ToolSet several levels in) don't change the fingerprint and would stay stale indefinitely. The colour cache, similarly, can mask a default-node-colour preference edit that doesn't surface in any menu change. And for hosts where the indexed item set genuinely changes a lot during a session — `tabtabtab_anchors` indexing live nodes in the script — anything cache-shaped on the show path is suspect.

Belt-and-suspenders: `close()` schedules a `_refresh_after_close()` via `QTimer.singleShot(0, ...)` that calls `plugin.invalidate_cache()` and forces a fresh walk in the background. New `TabTabTabPlugin.invalidate_cache()` hook (no-op default in core); `NukePlugin.invalidate_cache()` overrides to drop items + fingerprint + colour caches. Any change the show-path fingerprint would have missed is picked up here, so staleness is bounded to one popup behind any mid-session change. Cost is paid entirely in the post-close background path, never on the user's hot path; a re-open while the refresh is still pending is a no-op (`isVisible()` guard).

## Timing impact

User-reported timings against the unpatched code (cold Nuke session):

| Stage | Cold | Warm |
|---|---|---|
| `__init__` | 36 ms | — (cached) |
| `show()` total | 19 ms | 46 ms |
| **Time before line-edit ready** | **~57 ms** | **~46 ms** |

After this PR:

| Stage | Cold | Warm |
|---|---|---|
| `__init__` | runs in deferred preload, off the user's hot path | — |
| `show()` blocking part | `super().show()` + `setFocus` ≈ 3 ms | ≈ 3 ms |
| **Time before line-edit ready** | **~3 ms** | **~3 ms** |

Deferred refresh still runs after focus is established; on the warm path it hits Layer 2 caches and drops to single-digit ms. Belt-and-suspenders close-refresh runs in background after each close, so the next open's deferred refresh almost always finds a warm cache.

## Test plan

- [ ] Cold Nuke launch → press Tab immediately → first character of typed query is captured (no need to wait or retype)
- [ ] Press Tab → close → press Tab again rapidly → first character still captured (cached-instance path)
- [ ] Press Tab → press Tab again immediately (no characters between) → previously-created node is invoked (`[Tab][Tab]` fast-path preserved)
- [ ] Verify search results still match expected behaviour (filtering, scoring, space-prefix modes)
- [ ] Install a new gizmo *deeply nested* (under ToolSets/User/X for example) mid-session, press Tab → close → press Tab → new node appears in the list (belt-and-suspenders catches what the fingerprint missed)
- [ ] Edit a node's default colour in prefs, press Tab → close → press Tab → swatch reflects the change
- [ ] Quit Nuke after using the popup — no segfault on exit
- [ ] Quit Nuke without ever pressing Tab — no segfault on exit (preload strong-ref is released by `aboutToQuit` handler)
- [ ] If used: verify `tabtabtab_anchors` / paste_hidden plugin still sees newly-created anchors on each Tab open (refresh-on-show ensures items added since last open are visible)

## Notes

- Existing pytest suite passes (3/3 in `tabtabtab-nuke`).
- Sister-repo sync (per the `tabtabtab-core` source-of-truth rule) is a follow-up — the upstream `c005be3` and `b152083` commits modified the vendored `tabtabtab_nuke_core.py` directly, so canonical `tabtabtab-core/tabtabtab.py` is now slightly behind. Out of scope for this PR.
- No new tests added; the project's headless test setup can't exercise the Qt event-loop reordering or Nuke menu walk that this patch targets. Comprehensive test coverage is a separate effort.
- `[Tab][Tab]` ordering and Up/Down arrow timing edge cases were both raised in review and are addressed in the relevant threads.
