### PR TITLE
fix: bound popup staleness to one event-loop tick (#6)

### DIFF
--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -139,9 +139,10 @@ class NukePlugin(TabTabTabPlugin):
         avoids them entirely so the staleness check is essentially free.
 
         Belt-and-suspenders against fingerprint blind spots: TabTabTabWidget
-        calls invalidate_cache() after every popup close, so deeply nested
-        menu changes that the shallow fingerprint can't sample are still
-        picked up at most one popup later.
+        runs a second deferred refresh on every open that calls
+        invalidate_cache() and re-walks, so deeply nested menu changes
+        that the shallow fingerprint can't sample are picked up within
+        the same open (after a brief render of the cached data).
         """
         fingerprint = (
             _menu_fingerprint(nuke.menu("Nodes")),
@@ -165,17 +166,18 @@ class NukePlugin(TabTabTabPlugin):
         # Menu set changed (or first walk) — drop colour cache too in case
         # new node classes appeared. Independent invalidation of the colour
         # cache for default-colour preference edits happens via
-        # invalidate_cache() called from TabTabTabWidget._refresh_after_close.
+        # invalidate_cache() called from TabTabTabWidget._refresh_fresh.
         self._color_cache = {}
         return all_items
 
     def invalidate_cache(self):
         """Drop the items + fingerprint cache and the per-class colour
-        cache. Called by TabTabTabWidget._refresh_after_close after every
-        popup close so the next get_items() walks fresh data, regardless
-        of whether the shallow menu fingerprint would have caught the
-        change. Also clears colour memoisation so default-node-colour
-        preference edits show up on the next open."""
+        cache. Called by TabTabTabWidget._refresh_fresh on the second
+        deferred tick of every open so the get_items() that follows
+        walks fresh data, regardless of whether the shallow menu
+        fingerprint would have caught the change. Also clears colour
+        memoisation so default-node-colour preference edits show up on
+        the same open they were made on."""
         self._cached_items = None
         self._cached_menu_fingerprint = None
         self._color_cache = {}

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -726,10 +726,18 @@ class TabTabTabWidget(QtWidgets.QDialog):
         QtCore.QTimer.singleShot(0, self._refresh_after_show)
 
     def _refresh_after_show(self):
-        """Reload weights and refresh items from the plugin.
+        """Cheap refresh: reload weights and render whatever the plugin's
+        cache currently has, so the user has results to look at and can
+        type immediately.
 
         Runs on the next event-loop tick after show() so the user's first
         keystrokes land in the line-edit even though this work is slow.
+
+        Schedules _refresh_fresh on the following tick to bound staleness:
+        the cache may be one step behind reality (a deep submenu install
+        the plugin's fingerprint can't sample, or a default-node-colour
+        preference edit), and waiting until close to refresh would leave
+        the user staring at stale data for the entire open session.
         """
         # Load the weights everytime the panel is shown, to prevent
         # overwritting weights from other instances
@@ -741,34 +749,34 @@ class TabTabTabWidget(QtWidgets.QDialog):
         # Restore selection to the first item, since modelReset clears it
         self.move_selection(where="first")
 
-    def close(self):
-        """Save weights, close the dialog, and schedule a belt-and-suspenders
-        cache invalidation + refresh.
+        # Schedule the expensive freshness pass after focus and the cheap
+        # render are settled. The user can already type; this catches any
+        # staleness the plugin's own cache check missed.
+        QtCore.QTimer.singleShot(0, self._refresh_fresh)
 
-        The refresh on show() is the primary freshness mechanism — it walks
-        the plugin's items every open via _refresh_after_show, using the
-        plugin's own cache to skip the walk when nothing has changed. That's
-        adequate for hosts whose indexed items rarely change at runtime
-        (e.g. Nuke's node menus). For hosts where the indexed set changes
-        often during a session (e.g. tabtabtab_anchors indexing live nodes
-        in the script), or where the plugin's cache-validity check might
-        miss something (e.g. a deeply nested submenu install that a shallow
-        fingerprint doesn't sample), this hook ensures the cache is forcibly
-        invalidated and rewalked between every close and the next open.
-        """
-        self.weights.save()
-        super(TabTabTabWidget, self).close()
-        QtCore.QTimer.singleShot(0, self._refresh_after_close)
+    def _refresh_fresh(self):
+        """Expensive refresh: force a full re-walk of the plugin's items,
+        bypassing whatever cache the cheap path used.
 
-    def _refresh_after_close(self):
-        """Force a cache invalidation and a fresh walk in the background
-        after the popup closes. No-op if the user has already reopened the
-        popup before this fires — the show-time refresh will handle it.
+        Runs one tick after _refresh_after_show. Bounds staleness to a
+        brief moment after open instead of an entire open/close cycle,
+        at the cost of a possible slight typing hitch while the walk
+        runs. No-op if the user already closed the popup before this
+        fires — the next open will repeat the same two-stage refresh.
         """
-        if self.isVisible():
+        if not self.isVisible():
             return
         self.plugin.invalidate_cache()
         self.things_model.refresh_items(self.plugin.get_items())
+        # refresh_items resets the model, which clears QListView selection;
+        # restore to the first match (works for both empty and filtered
+        # input — _filtertext is preserved across refresh_items).
+        self.move_selection(where="first")
+
+    def close(self):
+        """Save weights and close the dialog."""
+        self.weights.save()
+        super(TabTabTabWidget, self).close()
 
     def create(self):
         # Get selected item


### PR DESCRIPTION
Closes #6.

## Background

PR #4 fixed the input-loss bug (#3) by deferring the menu walk and adding a `NukePlugin` cache keyed on a shallow (depth=2) name-only fingerprint. Belt-and-suspenders against fingerprint blind spots: after every popup close, `TabTabTabWidget._refresh_after_close` invalidated the cache and did a fresh walk in the background, so the *next* open was guaranteed fresh.

The downside: a deep submenu install or a default-node-colour preference edit isn't sampled by the fingerprint, so on the open *immediately following* such a change, the user sees stale data for the entire popup-open session. Only the open after that is fresh.

## Change

Replace the post-close refresh with a **second deferred refresh on the show path**:

1. `show()` — render widget, focus input. (Unchanged.)
2. `singleShot(0, _refresh_after_show)` — cheap path: load weights, render the cached items so the user can type immediately. (Unchanged structurally; now ends by scheduling the next step.)
3. `singleShot(0, _refresh_fresh)` *(new)* — expensive path: `plugin.invalidate_cache()` + fresh walk + restore selection. Guarded by `isVisible()` so a fast close drops the work.

`close()` is slimmed back to `weights.save()` + `super().close()`. `_refresh_after_close` is removed entirely.

## Tradeoff

| | Before (PR #4) | After |
|---|---|---|
| Worst-case staleness | One full open/close cycle | One event-loop tick after open |
| Cost on warm path | ~free (fingerprint hit) | One full menu walk per open, **after** the line-edit is ready |
| Failure mode | Stale popup until close, then fresh next time | Brief flicker as items refresh; possible slight typing hitch mid-keystroke |

The ~15ms walk PR #4 moved off the hot path is partially back, but on the deferred tick after focus is established — input loss should not regress.

## Test plan

- [ ] Cold Nuke launch → press Tab immediately → first character captured (PR #4 regression check)
- [ ] Type fast right after open — no input loss; possibly a brief result flicker
- [ ] Install a deeply nested gizmo (e.g. ToolSets/User/X) mid-session → press Tab → it appears within the same open
- [ ] Edit a default node colour in prefs → press Tab → swatch reflects the change in the same open
- [ ] `[Tab][Tab]` fast-path still works (previously created node)
- [ ] Quit Nuke after using popup — no segfault
- [ ] Quit Nuke without ever pressing Tab — no segfault

## Notes

- Existing pytest suite passes (3/3).
- Sister-repo sync (per the `tabtabtab-core` source-of-truth rule) is still pending — same drift as PR #4 noted. Out of scope here.
- Same caveat as PR #4: no new tests, since the headless suite can't exercise Qt event-loop reordering or the Nuke menu walk.