### PR TITLE
fix: parent popup to Nuke main window for clean shutdown

### DIFF
--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -795,26 +795,109 @@ class TabTabTabWidget(QtWidgets.QDialog):
 
 
 _tabtabtab_instance = None
-# Strong reference to a preloaded but never-yet-shown widget. Released
-# either on first show() (Qt's window registry takes over) or on
-# QApplication.aboutToQuit (whichever comes first), so the original
-# weakref-only lifetime pattern that avoids the on-exit segfault from
-# https://github.com/dbr/tabtabtab-nuke/issues/4 is restored before
-# host-application shutdown even if the user never opens the popup.
-_preloaded_instance = None
+
+
+_NUKE_MAIN_WINDOW_CLASSNAME = "Foundry::UI::DockMainWindow"
+
+
+def _find_nuke_main_window():
+    """Return Nuke's canonical main window (a QMainWindow), or None.
+
+    Nuke historically has multiple top-level QMainWindow instances —
+    floating panels, the Hiero/Studio bin/timeline, etc. Picking "the
+    first QMainWindow from topLevelWidgets()" is order-dependent and
+    can land us on a panel that the user later closes, taking our
+    popup with it. Identifying the main window canonically:
+
+      1. Match by Qt metaobject class name. Nuke's main window has a
+         stable className of "Foundry::UI::DockMainWindow" across
+         Nuke 11+; floating panels and other QMainWindows do not.
+      2. Fallback: any parentless QMainWindow whose title contains
+         " - Nuke" (matches "<file> - Nuke 14.0v5", "<file> - NukeX ...",
+         "<file> - NukeStudio ...", etc.) — covers modified Nuke
+         distributions or future class-name changes while still
+         excluding bare panels.
+      3. Otherwise None — better to be parentless than to grab a
+         floating panel and have the popup disappear when it closes.
+
+    Used as the Qt parent of the popup so its lifetime is owned by the
+    host. The host destroys child widgets in defined order during
+    shutdown, which avoids the dangling-wrapper segfault that the old
+    weakref-only pattern (dbr/tabtabtab-nuke#4) was working around.
+    """
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        return None
+
+    main_windows = [
+        widget for widget in app.topLevelWidgets()
+        if isinstance(widget, QtWidgets.QMainWindow)
+    ]
+
+    for widget in main_windows:
+        if widget.metaObject().className() == _NUKE_MAIN_WINDOW_CLASSNAME:
+            return widget
+
+    for widget in main_windows:
+        if widget.parent() is not None:
+            continue
+        title = widget.windowTitle() or ""
+        if " - Nuke" in title:
+            return widget
+
+    return None
+
+
+def _clear_tabtabtab_instance(*_args):
+    global _tabtabtab_instance
+    _tabtabtab_instance = None
+
+
+def _create_tabtabtab_widget(plugin, space_mode_order):
+    parent = _find_nuke_main_window()
+    # Qt.Dialog keeps the widget a top-level window even with a parent set.
+    # Without it, setWindowFlags(FramelessWindowHint) drops the dialog type
+    # and Qt treats the widget as a child of the parent — which puts it in
+    # the parent's z-stack (so the DAG can cover it) and stops it from
+    # receiving WindowDeactivate (so click-outside no longer closes it).
+    widget = TabTabTabWidget(
+        plugin,
+        parent=parent,
+        winflags=Qt.Dialog | Qt.FramelessWindowHint,
+        space_mode_order=space_mode_order,
+    )
+    widget.destroyed.connect(_clear_tabtabtab_instance)
+    return widget
 
 
 def launch(plugin, space_mode_order=None):
-    global _tabtabtab_instance, _preloaded_instance
+    global _tabtabtab_instance
 
     if _tabtabtab_instance is not None:
-        # TODO: Is there a better way of doing this? If a
-        # TabTabTabWidget is instanced, it goes out of scope at end of
-        # function and disappers instantly. This seems like a
-        # reasonable "workaround"
         try:
-            # Update space mode order on reuse so pref changes take
-            # effect without restarting the host application.
+            # Liveness probe before any attribute writes: parent() touches
+            # the underlying C++ object and raises RuntimeError if the
+            # wrapper is dangling, so the except below catches a dead
+            # widget cleanly rather than silently mutating things_model.
+            current_parent = _tabtabtab_instance.parent()
+
+            # Recover from preload-before-main-window: if preload() ran
+            # before Nuke's main window existed in topLevelWidgets(),
+            # _find_nuke_main_window() returned None and the cached
+            # instance is parentless — silently re-exposing the on-quit
+            # segfault from dbr/tabtabtab-nuke#4. Re-parent now if the
+            # main window has since appeared. setParent(parent, flags)
+            # also re-applies the window flags, which is required: a
+            # bare setParent on a top-level widget would demote it to a
+            # child of the main window's z-stack.
+            if current_parent is None:
+                rediscovered_parent = _find_nuke_main_window()
+                if rediscovered_parent is not None:
+                    _tabtabtab_instance.setParent(
+                        rediscovered_parent,
+                        Qt.Dialog | Qt.FramelessWindowHint,
+                    )
+
             if (space_mode_order is not None
                     and len(space_mode_order) == len(DEFAULT_SPACE_MODE_ORDER)
                     and all(m in VALID_MODES for m in space_mode_order)):
@@ -822,29 +905,19 @@ def launch(plugin, space_mode_order=None):
             _tabtabtab_instance.under_cursor()
             _tabtabtab_instance.show()
             _tabtabtab_instance.raise_()
-            # Once the widget has been shown, Qt holds it alive via its
-            # window registry. Drop the preload strong reference so we
-            # match the original lifetime model from here on.
-            _preloaded_instance = None
             return
-        except ReferenceError:
+        except RuntimeError:
+            # Defensive: in normal operation the destroyed-signal handler
+            # (_clear_tabtabtab_instance) nulls the global synchronously
+            # when the C++ widget is destroyed, so we should never reach
+            # this branch with a dangling wrapper. Kept in case a
+            # destroyed connection was ever severed or never wired up.
             _tabtabtab_instance = None
-            _preloaded_instance = None
 
-    t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint, space_mode_order=space_mode_order)
-
-    # Make dialog appear under cursor, as Nuke's builtin one does
-    t.under_cursor()
-
-    # Show, and make front-most window (mostly for OS X)
-    t.show()
-    t.raise_()
-
-    # Keep the TabTabTabWidget alive, but don't keep an extra
-    # reference to it, otherwise Nuke segfaults on exit. Hacky.
-    # https://github.com/dbr/tabtabtab-nuke/issues/4
-    import weakref
-    _tabtabtab_instance = weakref.proxy(t)
+    _tabtabtab_instance = _create_tabtabtab_widget(plugin, space_mode_order)
+    _tabtabtab_instance.under_cursor()
+    _tabtabtab_instance.show()
+    _tabtabtab_instance.raise_()
 
 
 def preload(plugin, space_mode_order=None):
@@ -860,38 +933,11 @@ def preload(plugin, space_mode_order=None):
     the host's own menu population, so prefer schedule_preload() which
     defers via QTimer.singleShot(0, ...).
     """
-    global _tabtabtab_instance, _preloaded_instance
+    global _tabtabtab_instance
     if _tabtabtab_instance is not None:
         return
 
-    t = TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint, space_mode_order=space_mode_order)
-    # Hold a strong reference until first show(); without this the proxy
-    # below would dangle the moment this function returns because Qt's
-    # window registry only tracks widgets that have been shown.
-    _preloaded_instance = t
-
-    # Defensively release the strong reference before the host application
-    # quits, even if the user never opens the popup. Holding an extra ref
-    # to the widget through Qt shutdown has caused segfaults historically
-    # (dbr/tabtabtab-nuke#4); aboutToQuit fires before Qt's cleanup pass,
-    # so dropping the ref here puts us back into the original weakref-
-    # only model in time.
-    app = QtWidgets.QApplication.instance()
-    if app is not None:
-        app.aboutToQuit.connect(_release_preloaded_instance)
-
-    import weakref
-    _tabtabtab_instance = weakref.proxy(t)
-
-
-def _release_preloaded_instance():
-    """aboutToQuit handler: drop strong + weak references to the preloaded
-    widget so Qt can tear it down without an extra Python reference
-    holding the wrapper alive past the C++ object's destruction.
-    """
-    global _preloaded_instance, _tabtabtab_instance
-    _preloaded_instance = None
-    _tabtabtab_instance = None
+    _tabtabtab_instance = _create_tabtabtab_widget(plugin, space_mode_order)
 
 
 def schedule_preload(plugin, space_mode_order=None):

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -853,6 +853,49 @@ def _clear_tabtabtab_instance(*_args):
     _tabtabtab_instance = None
 
 
+# Retry budget for preload-only re-parenting. Plugin-load typically runs
+# before Nuke's main window is registered in topLevelWidgets(), but the
+# main window appears within a second or two; ~10s of retries is enough
+# without spinning indefinitely if something genuinely went wrong.
+_REPARENT_RETRY_INTERVAL_MS = 500
+_REPARENT_RETRY_MAX_ATTEMPTS = 20
+
+
+def _try_reparent_preloaded(widget, attempts_remaining):
+    """Re-parent a parentless preloaded `widget` to Nuke's main window;
+    retry on a timer if the main window isn't in topLevelWidgets() yet.
+
+    Used from preload() to recover when preload runs before the main
+    window has been created. Without this, a session in which the user
+    never invokes the popup leaves the cached instance parentless for
+    the rest of the session — silently losing the parent-owned lifetime
+    that prevents the dbr/tabtabtab-nuke#4 segfault on host shutdown.
+
+    Bails out (no further retries) if the widget has been parented in
+    the meantime (e.g., by launch()'s recovery path), or if the widget
+    has become visible — at that point launch() owns recovery and a
+    re-parent here would disrupt the user's open popup.
+    """
+    try:
+        if widget.parent() is not None:
+            return
+        if widget.isVisible():
+            return
+    except RuntimeError:
+        return
+
+    parent = _find_nuke_main_window()
+    if parent is not None:
+        widget.setParent(parent, Qt.Dialog | Qt.FramelessWindowHint)
+        return
+
+    if attempts_remaining > 1:
+        QtCore.QTimer.singleShot(
+            _REPARENT_RETRY_INTERVAL_MS,
+            lambda: _try_reparent_preloaded(widget, attempts_remaining - 1),
+        )
+
+
 def _create_tabtabtab_widget(plugin, space_mode_order):
     parent = _find_nuke_main_window()
     # Qt.Dialog keeps the widget a top-level window even with a parent set.
@@ -938,6 +981,17 @@ def preload(plugin, space_mode_order=None):
         return
 
     _tabtabtab_instance = _create_tabtabtab_widget(plugin, space_mode_order)
+
+    # If the main window hadn't appeared yet, _create_tabtabtab_widget left
+    # the instance parentless. Schedule background retries so a preload-only
+    # session (user never invokes the popup) still ends up Qt-parented and
+    # benefits from the host-shutdown lifetime guarantee.
+    if _tabtabtab_instance.parent() is None:
+        preloaded_widget = _tabtabtab_instance
+        QtCore.QTimer.singleShot(
+            _REPARENT_RETRY_INTERVAL_MS,
+            lambda: _try_reparent_preloaded(preloaded_widget, _REPARENT_RETRY_MAX_ATTEMPTS),
+        )
 
 
 def schedule_preload(plugin, space_mode_order=None):

--- a/tests/test_main_window_discovery.py
+++ b/tests/test_main_window_discovery.py
@@ -1,0 +1,403 @@
+"""Tests for Nuke main window discovery and the parent re-attachment path
+used by preload() to recover from preload-before-main-window timing.
+
+Covers:
+  - _find_nuke_main_window() classname-match priority over other QMainWindows
+  - _find_nuke_main_window() title fallback for parentless windows
+  - _find_nuke_main_window() returning None when neither check matches
+  - _try_reparent_preloaded() parenting when the main window is available
+  - _try_reparent_preloaded() scheduling a retry when the main window is absent
+  - _try_reparent_preloaded() bailing out when the widget is already parented or visible
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+_NUKE_DOCK_CLASSNAME = "Foundry::UI::DockMainWindow"
+
+
+def _build_pyside_stubs(top_level_widgets_holder, scheduled_calls):
+    """Construct PySide6 stub modules with QApplication.instance() reading
+    from the mutable `top_level_widgets_holder` list and QTimer.singleShot
+    appending (delay_ms, callback) tuples to `scheduled_calls`.
+
+    The two outparams give tests a hook to mutate the topLevelWidgets list
+    after import (to simulate Nuke's main window appearing later) and to
+    drive scheduled retries deterministically without a real event loop.
+    """
+    pyside6 = types.ModuleType("PySide6")
+    qtcore = types.ModuleType("PySide6.QtCore")
+    qtgui = types.ModuleType("PySide6.QtGui")
+    qtwidgets = types.ModuleType("PySide6.QtWidgets")
+
+    qtcore.Qt = MagicMock()
+    qtcore.QEvent = MagicMock()
+    qtcore.QAbstractListModel = type("QAbstractListModel", (), {
+        "__init__": lambda self, *args, **kwargs: None,
+        "modelReset": MagicMock(),
+    })
+    qtcore.QModelIndex = MagicMock
+    qtcore.QSize = MagicMock
+    qtcore.QRect = MagicMock
+    qtcore.Signal = MagicMock(return_value=MagicMock())
+
+    class _StubQTimer:
+        @staticmethod
+        def singleShot(delay_ms, callback):
+            scheduled_calls.append((delay_ms, callback))
+
+    qtcore.QTimer = _StubQTimer
+
+    qtgui.QCursor = MagicMock()
+    qtgui.QIcon = MagicMock
+    qtgui.QColor = MagicMock
+    qtgui.QBrush = MagicMock
+    qtgui.QPen = MagicMock
+
+    qtwidgets.QDialog = type("QDialog", (), {"__init__": lambda self, *args, **kwargs: None})
+    qtwidgets.QLineEdit = type("QLineEdit", (), {"__init__": lambda self, *args, **kwargs: None})
+    qtwidgets.QListView = type("QListView", (), {"__init__": lambda self, *args, **kwargs: None})
+    qtwidgets.QVBoxLayout = type("QVBoxLayout", (), {"__init__": lambda self, *args, **kwargs: None})
+    qtwidgets.QStyledItemDelegate = type("QStyledItemDelegate", (), {"__init__": lambda self, *args, **kwargs: None})
+    qtwidgets.QStyle = MagicMock()
+    qtwidgets.QMainWindow = type("QMainWindow", (), {
+        "__init__": lambda self, *args, **kwargs: None,
+    })
+
+    class _StubQApplication:
+        @staticmethod
+        def instance():
+            app_mock = MagicMock()
+            app_mock.topLevelWidgets.return_value = list(top_level_widgets_holder)
+            return app_mock
+
+    qtwidgets.QApplication = _StubQApplication
+
+    pyside6.QtCore = qtcore
+    pyside6.QtGui = qtgui
+    pyside6.QtWidgets = qtwidgets
+
+    return pyside6, qtcore, qtgui, qtwidgets
+
+
+def _load_module(top_level_widgets_holder, scheduled_calls):
+    """Load tabtabtab_nuke_core with stubs wired to the given holders.
+
+    Returns (module, QMainWindowStub). Tests subclass the QMainWindow stub
+    to build fixtures that satisfy isinstance checks.
+    """
+    pyside6, qtcore, qtgui, qtwidgets = _build_pyside_stubs(
+        top_level_widgets_holder, scheduled_calls
+    )
+
+    stub_names = ["PySide6", "PySide6.QtCore", "PySide6.QtGui", "PySide6.QtWidgets"]
+    previous = {name: sys.modules.get(name) for name in stub_names}
+
+    sys.modules["PySide6"] = pyside6
+    sys.modules["PySide6.QtCore"] = qtcore
+    sys.modules["PySide6.QtGui"] = qtgui
+    sys.modules["PySide6.QtWidgets"] = qtwidgets
+
+    pyside2_stub = types.ModuleType("PySide2")
+    sys.modules.setdefault("PySide2", pyside2_stub)
+
+    core_path = os.path.join(os.path.dirname(__file__), "..", "tabtabtab_nuke_core.py")
+    spec = importlib.util.spec_from_file_location(
+        "tabtabtab_core_main_window_discovery_test", core_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name in stub_names:
+            if previous[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous[name]
+
+    return module, qtwidgets.QMainWindow
+
+
+def _make_mock_main_window(qmainwindow_class, classname="", parent_widget=None, title=""):
+    """Build a QMainWindow-subclass instance with controllable probe methods.
+
+    Subclassing the stub's QMainWindow is required so isinstance() checks
+    in _find_nuke_main_window() succeed; methods are attached per-instance
+    so each fixture can return its own classname/parent/title.
+    """
+    instance = qmainwindow_class.__new__(qmainwindow_class)
+    instance._classname = classname
+    instance._parent_widget = parent_widget
+    instance._title = title
+
+    def metaObject():
+        meta = MagicMock()
+        meta.className.return_value = instance._classname
+        return meta
+
+    instance.metaObject = metaObject
+    instance.parent = lambda: instance._parent_widget
+    instance.windowTitle = lambda: instance._title
+    return instance
+
+
+# --- _find_nuke_main_window tests ---------------------------------------
+
+
+def test_find_main_window_picks_classname_match_over_other_qmainwindows():
+    """The dock main window must win even when other QMainWindows are
+    present in arbitrary order (floating panels, Hiero/Studio bins, etc.).
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    floating_panel = _make_mock_main_window(
+        QMainWindow, classname="QMainWindow", title="Some Floating Panel"
+    )
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME, title="script.nk - NukeX 14.0v5"
+    )
+    other_panel = _make_mock_main_window(
+        QMainWindow, classname="QMainWindow", title="Another Panel"
+    )
+
+    # Place dock main between two non-matching QMainWindows; classname check
+    # must select dock_main regardless of position.
+    top_level.extend([floating_panel, dock_main, other_panel])
+
+    assert module._find_nuke_main_window() is dock_main
+
+
+def test_find_main_window_falls_back_to_title_match_for_parentless_window():
+    """If no widget matches the classname, the parentless title-match
+    fallback should kick in for the canonical Nuke title shape.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    nuke_main = _make_mock_main_window(
+        QMainWindow, classname="QMainWindow", title="script.nk - Nuke 14.0v5"
+    )
+    top_level.append(nuke_main)
+
+    assert module._find_nuke_main_window() is nuke_main
+
+
+def test_find_main_window_title_fallback_excludes_parented_panels():
+    """A QMainWindow whose title contains ' - Nuke' but which has a parent
+    is presumably an embedded panel; the fallback must skip it.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    parent_widget_marker = MagicMock()
+    parented_panel = _make_mock_main_window(
+        QMainWindow,
+        classname="QMainWindow",
+        parent_widget=parent_widget_marker,
+        title="something - Nuke 14.0v5",
+    )
+    top_level.append(parented_panel)
+
+    assert module._find_nuke_main_window() is None
+
+
+def test_find_main_window_returns_none_when_nothing_matches():
+    """No classname match and no title-bearing parentless QMainWindow ->
+    return None rather than fall back to grabbing an arbitrary panel.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    arbitrary_panel = _make_mock_main_window(
+        QMainWindow, classname="QMainWindow", title="just a panel"
+    )
+    top_level.append(arbitrary_panel)
+
+    assert module._find_nuke_main_window() is None
+
+
+def test_find_main_window_classname_match_recognised_via_metaobject():
+    """Title shape doesn't matter when the classname matches — covers the
+    case where a script hasn't been opened yet (default Nuke title).
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME, title=""
+    )
+    top_level.append(dock_main)
+
+    assert module._find_nuke_main_window() is dock_main
+
+
+# --- _try_reparent_preloaded tests --------------------------------------
+
+
+def _make_preload_widget(currently_parented=False, currently_visible=False):
+    """Build a widget mock that records setParent calls and exposes
+    parent()/isVisible() probes the helper checks before re-parenting.
+    """
+    widget = MagicMock()
+    widget.parent.return_value = MagicMock() if currently_parented else None
+    widget.isVisible.return_value = currently_visible
+    return widget
+
+
+def test_try_reparent_parents_widget_when_main_window_available():
+    """Happy path: parentless widget + main window in topLevelWidgets()
+    -> setParent called with the main window and the right window flags.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME
+    )
+    top_level.append(dock_main)
+
+    widget = _make_preload_widget()
+
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+
+    widget.setParent.assert_called_once()
+    parent_arg, flags_arg = widget.setParent.call_args[0]
+    assert parent_arg is dock_main
+    # Flags arg should be the OR of Qt.Dialog and Qt.FramelessWindowHint —
+    # we don't try to introspect MagicMock OR results, but we do require
+    # that setParent received two positional args (parent + flags) so a
+    # bare setParent(parent) call (which would demote to a child) doesn't
+    # silently slip through.
+    assert flags_arg is not None
+    assert not scheduled, "should not schedule retry once parented"
+
+
+def test_try_reparent_schedules_retry_when_main_window_absent():
+    """No main window present -> setParent not called, retry scheduled."""
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    widget = _make_preload_widget()
+
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+
+    widget.setParent.assert_not_called()
+    assert len(scheduled) == 1
+    delay_ms, callback = scheduled[0]
+    assert delay_ms == module._REPARENT_RETRY_INTERVAL_MS
+    assert callable(callback)
+
+
+def test_try_reparent_eventually_succeeds_when_main_window_appears():
+    """Realistic preload race: first attempt finds nothing, main window
+    appears between retries, next retry parents the widget.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    widget = _make_preload_widget()
+
+    # First attempt: no main window yet.
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+    widget.setParent.assert_not_called()
+    assert len(scheduled) == 1
+
+    # Main window appears.
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME
+    )
+    top_level.append(dock_main)
+
+    # Drive the scheduled retry callback.
+    _delay, retry_callback = scheduled[0]
+    scheduled.clear()
+    retry_callback()
+
+    widget.setParent.assert_called_once()
+    parent_arg = widget.setParent.call_args[0][0]
+    assert parent_arg is dock_main
+    assert not scheduled, "should not schedule another retry once parented"
+
+
+def test_try_reparent_stops_after_max_attempts():
+    """Attempt budget exhaustion -> no further retry scheduled."""
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    widget = _make_preload_widget()
+    module._try_reparent_preloaded(widget, attempts_remaining=1)
+
+    widget.setParent.assert_not_called()
+    assert scheduled == [], "last attempt must not enqueue another retry"
+
+
+def test_try_reparent_skips_when_widget_already_parented():
+    """If launch()'s recovery path beat us to it, the helper must do
+    nothing — no setParent, no retry.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME
+    )
+    top_level.append(dock_main)
+
+    widget = _make_preload_widget(currently_parented=True)
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+
+    widget.setParent.assert_not_called()
+    assert scheduled == []
+
+
+def test_try_reparent_skips_when_widget_visible():
+    """If the user opened the popup before the retry fired, leave it
+    alone — re-parenting a visible widget would disrupt the open dialog
+    and launch() owns recovery from this point on.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    dock_main = _make_mock_main_window(
+        QMainWindow, classname=_NUKE_DOCK_CLASSNAME
+    )
+    top_level.append(dock_main)
+
+    widget = _make_preload_widget(currently_visible=True)
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+
+    widget.setParent.assert_not_called()
+    assert scheduled == []
+
+
+def test_try_reparent_skips_when_widget_destroyed():
+    """If the underlying C++ widget has been destroyed, parent() raises
+    RuntimeError; the helper must swallow it and stop retrying.
+    """
+    top_level = []
+    scheduled = []
+    module, QMainWindow = _load_module(top_level, scheduled)
+
+    widget = MagicMock()
+    widget.parent.side_effect = RuntimeError("wrapped C++ object destroyed")
+
+    module._try_reparent_preloaded(widget, attempts_remaining=5)
+
+    widget.setParent.assert_not_called()
+    assert scheduled == []


### PR DESCRIPTION
Closes #5

## Summary
- Replaces the weakref-proxy + opt-in strong-ref + aboutToQuit dance with a Qt-parent-owned widget lifetime; the popup is parented to Nuke's `DockMainWindow` so Qt tears it down during host shutdown — addressing the on-quit segfault from dbr/tabtabtab-nuke#4 without the weakref hack.
- Identifies the main window canonically by metaobject classname (`Foundry::UI::DockMainWindow`) with a window-title fallback (`" - Nuke"` substring covers `Nuke`, `NukeX`, `NukeStudio`, `NukeAssist`), avoiding the order-dependent "first QMainWindow in topLevelWidgets()" heuristic that could attach the popup to a floating panel.
- If `preload()` runs before the main window exists, the widget is constructed parentless and re-parented on the next `launch()` via `setParent(parent, Qt.Dialog | FramelessWindowHint)` so the lifetime guarantee isn't silently lost.
- Liveness probe on the reuse path is now `parent()` (touches the C++ object), and the `RuntimeError` catch is documented as defensive — the `destroyed` signal handler nulls the cached instance synchronously in normal operation.

## Notes for review
- `Qt.Dialog | Qt.FramelessWindowHint` is intentional: dropping `Qt.Dialog` would demote the parented widget to a child of the main window's z-stack and stop it from receiving `WindowDeactivate` (breaking click-outside dismissal).
- The `_clear_tabtabtab_instance(*_args)` variadic signature is intentional — `destroyed`'s payload differs between PySide2 and PySide6.

## Test plan
- [ ] Open popup via shortcut, type, select a node — popup behaves as before.
- [ ] Open and close popup repeatedly — same instance is reused (no re-construction lag).
- [ ] Click outside the popup — it dismisses.
- [ ] Change `space_mode_order` preference between opens — new order takes effect on the next open without restart.
- [ ] Quit Nuke with the popup having been opened at least once — no segfault on exit.
- [ ] Quit Nuke without ever opening the popup (preload-only path) — no segfault on exit.
- [ ] Verify on Nuke 11 / 13 / 14 (or whichever versions are in your test matrix) — classname match should hit step 1, never falling through to the title fallback.
