### PR TITLE
fix: incremental model updates + synchronous show()-time refresh

### DIFF
--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -420,73 +420,91 @@ class NodeModel(QtCore.QAbstractListModel):
         """Replace visible items via minimal row operations instead of a
         full modelReset.
 
-        Diff is keyed on `menupath` (each item's stable identity) over
-        the visible window only — rowCount is capped at num_items, so
-        anything past that is invisible to Qt and can be swapped silently.
+        Mutates self._items in place between every begin*/end* pair so
+        rowCount() reflects the post-mutation state by the time end* is
+        called — that's the Qt contract. An earlier version mutated a
+        local slice copy, leaving self._items stale through the whole
+        run; views querying mid-emission saw inconsistent state.
+
+        Diff is keyed on `menupath` (each item's stable identity).
+        new_items is capped at num_items at entry; everything past that
+        is dead storage (data()/getorig() never read past rowCount, and
+        update() rebuilds from self._all so off-window retention buys
+        nothing). rowCount() now returns len(self._items) directly.
 
         Why this matters: the deferred refresh on popup show ran
-        modelReset twice (once for the cheap pass, once for the fresh
-        re-walk), which blanked the view, cleared selection, and made
-        results visibly "jump" each tick. Emitting begin/end Insert /
-        Remove / Move keeps the view stable across refreshes — the user
-        sees the previous open's results immediately, and they morph
-        into current as the timers tick instead of flashing through an
-        empty state.
+        modelReset twice (cheap pass + fresh re-walk), blanking the
+        view and clearing selection. Row ops keep the view stable —
+        the user sees the previous open's items immediately and they
+        morph into current as the timers tick.
         """
         parent = QtCore.QModelIndex()
         n = self.num_items
-        visible_old = self._items[:n]
-        visible_new = new_items[:n]
+        # Cap both lists at the visible window. self._items may have
+        # been longer under the previous (capped-rowCount) regime; trim
+        # silently before any signal emission so the diff loop's first
+        # begin* call sees a consistent rowCount.
+        if len(self._items) > n:
+            del self._items[n:]
+        new_items = new_items[:n]
 
-        new_key_set = {item['menupath'] for item in visible_new}
+        new_key_set = {item['menupath'] for item in new_items}
 
-        # Remove rows whose key is no longer present, walking back-to-front
-        # so earlier indices stay valid as we delete.
-        for i in range(len(visible_old) - 1, -1, -1):
-            if visible_old[i]['menupath'] not in new_key_set:
+        # Remove rows whose key is no longer present, walking back-to-
+        # front so earlier indices stay valid as we delete.
+        for i in range(len(self._items) - 1, -1, -1):
+            if self._items[i]['menupath'] not in new_key_set:
                 self.beginRemoveRows(parent, i, i)
-                del visible_old[i]
+                del self._items[i]
                 self.endRemoveRows()
 
         # Walk the target order. At each position, ensure the right row
         # is present — moving an existing one up, or inserting a new one.
-        for target_pos, new_item in enumerate(visible_new):
+        for target_pos, new_item in enumerate(new_items):
             key = new_item['menupath']
 
-            if (target_pos < len(visible_old)
-                    and visible_old[target_pos]['menupath'] == key):
-                if not self._row_visually_equal(visible_old[target_pos], new_item):
-                    visible_old[target_pos] = new_item
+            if (target_pos < len(self._items)
+                    and self._items[target_pos]['menupath'] == key):
+                if not self._row_visually_equal(self._items[target_pos], new_item):
+                    self._items[target_pos] = new_item
                     idx = self.index(target_pos)
                     self.dataChanged.emit(idx, idx)
                 continue
 
             source_pos = None
-            for j in range(target_pos + 1, len(visible_old)):
-                if visible_old[j]['menupath'] == key:
+            for j in range(target_pos + 1, len(self._items)):
+                if self._items[j]['menupath'] == key:
                     source_pos = j
                     break
 
             if source_pos is not None:
                 # source_pos > target_pos always here, so destinationChild
                 # = target_pos is a valid move (Qt rejects no-op moves
-                # where dest == source or source + 1).
-                self.beginMoveRows(parent, source_pos, source_pos, parent, target_pos)
-                visible_old.insert(target_pos, visible_old.pop(source_pos))
-                self.endMoveRows()
-                if not self._row_visually_equal(visible_old[target_pos], new_item):
-                    visible_old[target_pos] = new_item
-                    idx = self.index(target_pos)
-                    self.dataChanged.emit(idx, idx)
+                # where dest == source or source + 1). beginMoveRows
+                # returns False if Qt rejects anyway; fall back to
+                # remove+insert so we never run endMoveRows against a
+                # rejected begin.
+                moved = self.beginMoveRows(
+                    parent, source_pos, source_pos, parent, target_pos
+                )
+                if moved:
+                    self._items.insert(target_pos, self._items.pop(source_pos))
+                    self.endMoveRows()
+                    if not self._row_visually_equal(self._items[target_pos], new_item):
+                        self._items[target_pos] = new_item
+                        idx = self.index(target_pos)
+                        self.dataChanged.emit(idx, idx)
+                else:
+                    self.beginRemoveRows(parent, source_pos, source_pos)
+                    del self._items[source_pos]
+                    self.endRemoveRows()
+                    self.beginInsertRows(parent, target_pos, target_pos)
+                    self._items.insert(target_pos, new_item)
+                    self.endInsertRows()
             else:
                 self.beginInsertRows(parent, target_pos, target_pos)
-                visible_old.insert(target_pos, new_item)
+                self._items.insert(target_pos, new_item)
                 self.endInsertRows()
-
-        # Off-window items are invisible to the view; assign without
-        # emitting. Keep new_items[n:] so a later filter that narrows
-        # the result set can still draw from the full pool.
-        self._items = visible_old + new_items[n:]
 
     @staticmethod
     def _row_visually_equal(old_row, new_row):
@@ -501,7 +519,7 @@ class NodeModel(QtCore.QAbstractListModel):
         )
 
     def rowCount(self, parent=QtCore.QModelIndex()):
-        return min(self.num_items, len(self._items))
+        return len(self._items)
 
     def data(self, index, role=Qt.DisplayRole):
         if role == Qt.DisplayRole:
@@ -795,42 +813,70 @@ class TabTabTabWidget(QtWidgets.QDialog):
         create previously created node (instead of the most popular)
         """
 
-        # Run the cheap refresh synchronously so items are visible the
-        # instant the popup paints. weights.load() + plugin.get_items()
-        # against a warm cache is sub-millisecond; the 100-400ms cost
-        # that motivated the original deferral lives in invalidate_cache()
-        # + full re-walk, which is still deferred via _refresh_fresh.
+        # Show the widget and focus the input *before* doing any heavy work.
+        # Reloading weights from disk and re-walking the host application's
+        # menus can take 100-400ms; if those run synchronously here, queued
+        # KeyPress events arrive before the line-edit is ready and the user's
+        # first character or two get lost (issue #3). Deferring via
+        # singleShot(0) lets Qt drain pending input events into the now-
+        # focused line-edit before the refresh blocks the GUI thread again.
         #
-        # NodeModel now emits row ops (not modelReset), so even if this
-        # cheap pass produces a slightly different list than the previous
-        # open, the user sees an incremental morph instead of a blank-
-        # and-rebuild flash.
-        self.weights.load()
-        self.things_model.refresh_items(self.plugin.get_items())
-        self.move_selection(where="first")
-
+        # The popup's previous-open items remain in NodeModel between
+        # close and re-open. Now that NodeModel emits row ops instead of
+        # modelReset, the deferred refreshes morph that retained state
+        # incrementally — no blank flash between show() and the first
+        # tick, and no jump when the second tick fires.
         self.input.selectAll()
         super(TabTabTabWidget, self).show()
         self.input.setFocus()
 
-        # Schedule the expensive freshness pass on the next tick. The
-        # user can already see results and type; this catches any
+        QtCore.QTimer.singleShot(0, self._refresh_after_show)
+
+    def _refresh_after_show(self):
+        """Cheap refresh: reload weights and render whatever the plugin's
+        cache currently has, so the user has results to look at and can
+        type immediately.
+
+        Runs on the next event-loop tick after show() so the user's first
+        keystrokes land in the line-edit even though this work is slow.
+
+        Schedules _refresh_fresh on the following tick to bound staleness:
+        the cache may be one step behind reality (a deep submenu install
+        the plugin's fingerprint can't sample, or a default-node-colour
+        preference edit), and waiting until close to refresh would leave
+        the user staring at stale data for the entire open session.
+        """
+        # Load the weights everytime the panel is shown, to prevent
+        # overwritting weights from other instances
+        self.weights.load()
+
+        # Refresh items from the plugin so additions/removals are reflected.
+        # NodeModel emits row ops, so this pass quietly morphs the retained
+        # previous-open state into current results without blanking the view.
+        self.things_model.refresh_items(self.plugin.get_items())
+
+        # Restore selection to the first item; row ops preserve selection
+        # in general, but a previously-selected row may no longer exist.
+        self.move_selection(where="first")
+
+        # Schedule the expensive freshness pass after focus and the cheap
+        # render are settled. The user can already type; this catches any
         # staleness the plugin's own cache check missed.
         QtCore.QTimer.singleShot(0, self._refresh_fresh)
 
     def _refresh_fresh(self):
         """Expensive refresh: force a full re-walk of the plugin's items,
-        bypassing whatever cache the synchronous show()-time pass used.
+        bypassing whatever cache the cheap path used.
 
-        Runs one tick after show(). Bounds staleness to a brief moment
-        after open instead of an entire open/close cycle, at the cost
-        of a possible slight typing hitch while the walk runs. No-op
-        if the user already closed the popup before this fires — the
-        next open will repeat the same two-stage refresh.
+        Runs one tick after _refresh_after_show. Bounds staleness to a
+        brief moment after open instead of an entire open/close cycle,
+        at the cost of a possible slight typing hitch while the walk
+        runs. No-op if the user already closed the popup before this
+        fires — the next open will repeat the same two-stage refresh.
 
-        NodeModel now emits row ops rather than modelReset, so this
-        pass is visually quiet when nothing changed: only the rows
-        that genuinely differ get touched.
+        NodeModel emits row ops rather than modelReset, so this pass is
+        visually quiet when nothing changed: only rows that genuinely
+        differ get touched.
         """
         if not self.isVisible():
             return

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -414,8 +414,91 @@ class NodeModel(QtCore.QAbstractListModel):
         sort_b = sorted(scored_b, key=lambda k: (-k['score'], k['text']))
         s = sort_a + sort_b
 
-        self._items = s
-        self.modelReset.emit()
+        self._apply_items(s)
+
+    def _apply_items(self, new_items):
+        """Replace visible items via minimal row operations instead of a
+        full modelReset.
+
+        Diff is keyed on `menupath` (each item's stable identity) over
+        the visible window only — rowCount is capped at num_items, so
+        anything past that is invisible to Qt and can be swapped silently.
+
+        Why this matters: the deferred refresh on popup show ran
+        modelReset twice (once for the cheap pass, once for the fresh
+        re-walk), which blanked the view, cleared selection, and made
+        results visibly "jump" each tick. Emitting begin/end Insert /
+        Remove / Move keeps the view stable across refreshes — the user
+        sees the previous open's results immediately, and they morph
+        into current as the timers tick instead of flashing through an
+        empty state.
+        """
+        parent = QtCore.QModelIndex()
+        n = self.num_items
+        visible_old = self._items[:n]
+        visible_new = new_items[:n]
+
+        new_key_set = {item['menupath'] for item in visible_new}
+
+        # Remove rows whose key is no longer present, walking back-to-front
+        # so earlier indices stay valid as we delete.
+        for i in range(len(visible_old) - 1, -1, -1):
+            if visible_old[i]['menupath'] not in new_key_set:
+                self.beginRemoveRows(parent, i, i)
+                del visible_old[i]
+                self.endRemoveRows()
+
+        # Walk the target order. At each position, ensure the right row
+        # is present — moving an existing one up, or inserting a new one.
+        for target_pos, new_item in enumerate(visible_new):
+            key = new_item['menupath']
+
+            if (target_pos < len(visible_old)
+                    and visible_old[target_pos]['menupath'] == key):
+                if not self._row_visually_equal(visible_old[target_pos], new_item):
+                    visible_old[target_pos] = new_item
+                    idx = self.index(target_pos)
+                    self.dataChanged.emit(idx, idx)
+                continue
+
+            source_pos = None
+            for j in range(target_pos + 1, len(visible_old)):
+                if visible_old[j]['menupath'] == key:
+                    source_pos = j
+                    break
+
+            if source_pos is not None:
+                # source_pos > target_pos always here, so destinationChild
+                # = target_pos is a valid move (Qt rejects no-op moves
+                # where dest == source or source + 1).
+                self.beginMoveRows(parent, source_pos, source_pos, parent, target_pos)
+                visible_old.insert(target_pos, visible_old.pop(source_pos))
+                self.endMoveRows()
+                if not self._row_visually_equal(visible_old[target_pos], new_item):
+                    visible_old[target_pos] = new_item
+                    idx = self.index(target_pos)
+                    self.dataChanged.emit(idx, idx)
+            else:
+                self.beginInsertRows(parent, target_pos, target_pos)
+                visible_old.insert(target_pos, new_item)
+                self.endInsertRows()
+
+        # Off-window items are invisible to the view; assign without
+        # emitting. Keep new_items[n:] so a later filter that narrows
+        # the result set can still draw from the full pool.
+        self._items = visible_old + new_items[n:]
+
+    @staticmethod
+    def _row_visually_equal(old_row, new_row):
+        """True if two rows would render identically. Compares only the
+        fields the delegate reads — skipping `menuobj` (host handle,
+        identity comparison is unreliable) and `menupath` (already
+        matched by caller)."""
+        return (
+            old_row.get('display_text') == new_row.get('display_text')
+            and old_row.get('score') == new_row.get('score')
+            and old_row.get('color') == new_row.get('color')
+        )
 
     def rowCount(self, parent=QtCore.QModelIndex()):
         return min(self.num_items, len(self._items))
@@ -712,65 +795,47 @@ class TabTabTabWidget(QtWidgets.QDialog):
         create previously created node (instead of the most popular)
         """
 
-        # Show the widget and focus the input *before* doing any heavy work.
-        # Reloading weights from disk and re-walking the host application's
-        # menus can take 100-400ms; if those run synchronously here, queued
-        # KeyPress events arrive before the line-edit is ready and the user's
-        # first character or two get lost (issue #3). Deferring via
-        # singleShot(0) lets Qt drain pending input events into the now-
-        # focused line-edit before the refresh blocks the GUI thread again.
+        # Run the cheap refresh synchronously so items are visible the
+        # instant the popup paints. weights.load() + plugin.get_items()
+        # against a warm cache is sub-millisecond; the 100-400ms cost
+        # that motivated the original deferral lives in invalidate_cache()
+        # + full re-walk, which is still deferred via _refresh_fresh.
+        #
+        # NodeModel now emits row ops (not modelReset), so even if this
+        # cheap pass produces a slightly different list than the previous
+        # open, the user sees an incremental morph instead of a blank-
+        # and-rebuild flash.
+        self.weights.load()
+        self.things_model.refresh_items(self.plugin.get_items())
+        self.move_selection(where="first")
+
         self.input.selectAll()
         super(TabTabTabWidget, self).show()
         self.input.setFocus()
 
-        QtCore.QTimer.singleShot(0, self._refresh_after_show)
-
-    def _refresh_after_show(self):
-        """Cheap refresh: reload weights and render whatever the plugin's
-        cache currently has, so the user has results to look at and can
-        type immediately.
-
-        Runs on the next event-loop tick after show() so the user's first
-        keystrokes land in the line-edit even though this work is slow.
-
-        Schedules _refresh_fresh on the following tick to bound staleness:
-        the cache may be one step behind reality (a deep submenu install
-        the plugin's fingerprint can't sample, or a default-node-colour
-        preference edit), and waiting until close to refresh would leave
-        the user staring at stale data for the entire open session.
-        """
-        # Load the weights everytime the panel is shown, to prevent
-        # overwritting weights from other instances
-        self.weights.load()
-
-        # Refresh items from the plugin so additions/removals are reflected
-        self.things_model.refresh_items(self.plugin.get_items())
-
-        # Restore selection to the first item, since modelReset clears it
-        self.move_selection(where="first")
-
-        # Schedule the expensive freshness pass after focus and the cheap
-        # render are settled. The user can already type; this catches any
+        # Schedule the expensive freshness pass on the next tick. The
+        # user can already see results and type; this catches any
         # staleness the plugin's own cache check missed.
         QtCore.QTimer.singleShot(0, self._refresh_fresh)
 
     def _refresh_fresh(self):
         """Expensive refresh: force a full re-walk of the plugin's items,
-        bypassing whatever cache the cheap path used.
+        bypassing whatever cache the synchronous show()-time pass used.
 
-        Runs one tick after _refresh_after_show. Bounds staleness to a
-        brief moment after open instead of an entire open/close cycle,
-        at the cost of a possible slight typing hitch while the walk
-        runs. No-op if the user already closed the popup before this
-        fires — the next open will repeat the same two-stage refresh.
+        Runs one tick after show(). Bounds staleness to a brief moment
+        after open instead of an entire open/close cycle, at the cost
+        of a possible slight typing hitch while the walk runs. No-op
+        if the user already closed the popup before this fires — the
+        next open will repeat the same two-stage refresh.
+
+        NodeModel now emits row ops rather than modelReset, so this
+        pass is visually quiet when nothing changed: only the rows
+        that genuinely differ get touched.
         """
         if not self.isVisible():
             return
         self.plugin.invalidate_cache()
         self.things_model.refresh_items(self.plugin.get_items())
-        # refresh_items resets the model, which clears QListView selection;
-        # restore to the first match (works for both empty and filtered
-        # input — _filtertext is preserved across refresh_items).
         self.move_selection(where="first")
 
     def close(self):

--- a/tests/test_node_model_diff.py
+++ b/tests/test_node_model_diff.py
@@ -283,33 +283,88 @@ def test_mixed_remove_insert_and_reorder_orders_removes_first():
     assert last_remove < first_struct_after_remove
 
 
-def test_off_window_churn_is_silent():
-    """Items past num_items aren't visible to Qt (rowCount caps), so
-    swapping them emits no row operations."""
+def test_input_past_num_items_is_equivalent_to_capped_input():
+    """new_items past num_items is dead storage — capping at entry
+    produces the same signal trace and same final state as if the
+    caller had pre-capped the list themselves."""
     module = _load_core()
+    full_input = [_row(letter) for letter in "EABCD"]
+
+    model_uncapped = _make_model(module, num_items=3, items=[_row(c) for c in "ABC"])
+    model_uncapped._apply_items(full_input)
+
+    model_capped = _make_model(module, num_items=3, items=[_row(c) for c in "ABC"])
+    model_capped._apply_items(full_input[:3])
+
+    assert model_uncapped.recorded_ops == model_capped.recorded_ops
+    assert (
+        [i["menupath"] for i in model_uncapped._items]
+        == [i["menupath"] for i in model_capped._items]
+    )
+
+
+def test_pre_existing_off_window_items_are_trimmed_silently():
+    """If self._items entered the call with items past num_items (legacy
+    state from an older capped-rowCount regime), those are silently
+    trimmed before any signal emission so the diff loop's first begin*
+    call sees a rowCount that matches reality."""
+    module = _load_core()
+    # Five items in storage, only three visible — same input as state.
     items = [_row(letter) for letter in "ABCDE"]
     model = _make_model(module, num_items=3, items=items)
 
-    # Visible window unchanged (A, B, C); off-window swapped D,E -> F,G.
-    model._apply_items([_row("A"), _row("B"), _row("C"), _row("F"), _row("G")])
+    model._apply_items([_row("A"), _row("B"), _row("C")])
 
     assert model.recorded_ops == []
-    assert [i["menupath"] for i in model._items] == ["A", "B", "C", "F", "G"]
+    assert [i["menupath"] for i in model._items] == ["A", "B", "C"]
 
 
-def test_off_window_item_promoted_into_window_emits_structural_ops():
-    """When something previously off-window enters the visible window,
-    that crossing must surface — otherwise the user wouldn't see the
-    new top-of-list item appear."""
+def test_self_items_consistent_at_end_of_each_pair():
+    """Qt contract: between begin* and end*, the model must mutate its
+    backing data so rowCount() reflects the post-operation count by the
+    time end* fires. An earlier version mutated a local slice copy and
+    only assigned to self._items at the very end of _apply_items, which
+    left rowCount() lying through every begin/end pair.
+
+    This test instruments the stub's end* methods to capture
+    len(model._items) at the moment each fires and asserts the captured
+    counts match the per-step expected sequence — proving the mutation
+    is propagating to self._items in step with the signals.
+    """
     module = _load_core()
-    items = [_row(letter) for letter in "ABCDE"]
-    model = _make_model(module, num_items=3, items=items)
+    model = _make_model(module, items=[_row("A"), _row("B"), _row("C")])
 
-    # E was off-window (position 4); now it's at position 0.
-    # Visible window must shift from [A, B, C] to [E, A, B].
-    model._apply_items([_row("E"), _row("A"), _row("B"), _row("C"), _row("D")])
+    snapshots = []
+    original_end_remove = type(model).endRemoveRows
+    original_end_insert = type(model).endInsertRows
+    original_end_move = type(model).endMoveRows
 
-    op_kinds = [op[0] for op in model.recorded_ops]
-    assert "begin_insert" in op_kinds  # E entering the window
-    assert "begin_remove" in op_kinds  # C leaving the window
-    assert [i["menupath"] for i in model._items[:3]] == ["E", "A", "B"]
+    def capturing_end_remove(self):
+        snapshots.append(("end_remove", len(self._items)))
+        original_end_remove(self)
+
+    def capturing_end_insert(self):
+        snapshots.append(("end_insert", len(self._items)))
+        original_end_insert(self)
+
+    def capturing_end_move(self):
+        snapshots.append(("end_move", len(self._items)))
+        original_end_move(self)
+
+    model.endRemoveRows = capturing_end_remove.__get__(model, type(model))
+    model.endInsertRows = capturing_end_insert.__get__(model, type(model))
+    model.endMoveRows = capturing_end_move.__get__(model, type(model))
+
+    # Old: A B C (len 3). New: D A (B and C removed, D inserted at top).
+    # Expected snapshots in order:
+    #   end_remove → len 2 (C gone)
+    #   end_remove → len 1 (B gone)
+    #   end_insert → len 2 (D inserted at 0; A still at what's now 1)
+    model._apply_items([_row("D"), _row("A")])
+
+    assert snapshots == [
+        ("end_remove", 2),
+        ("end_remove", 1),
+        ("end_insert", 2),
+    ]
+    assert [i["menupath"] for i in model._items] == ["D", "A"]

--- a/tests/test_node_model_diff.py
+++ b/tests/test_node_model_diff.py
@@ -1,0 +1,315 @@
+"""Tests for NodeModel._apply_items incremental diff.
+
+Verifies that the diff emits the minimum set of row operations to morph
+one visible item set into another, instead of falling back to modelReset.
+This is what keeps the popup's selection stable across the deferred
+fresh-refresh tick on show() and avoids visible flicker.
+
+Covers:
+  - No-op when before/after lists match → zero row operations.
+  - Pure insertion into an empty model → ordered beginInsertRows.
+  - Pure removal → back-to-front beginRemoveRows so indices stay valid.
+  - Reorder of identical items → beginMoveRows, no inserts or removes.
+  - In-place score change → dataChanged only, no structural ops.
+  - Visually-identical refresh → no dataChanged emitted (quiet refresh).
+  - Mixed remove/insert/reorder → removes precede inserts and moves.
+  - num_items cap → off-window churn is silent; off-window items
+    promoted into the visible window do surface as inserts.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class _StubIndex:
+    """Stand-in for QModelIndex; only .row() is exercised."""
+
+    def __init__(self, row=-1):
+        self._row = row
+
+    def row(self):
+        return self._row
+
+
+class _RecordingDataChanged:
+    """Stand-in for the QAbstractListModel.dataChanged signal that
+    appends each emit to the owning model's recorded_ops list."""
+
+    def __init__(self, owner):
+        self._owner = owner
+
+    def emit(self, top, bottom):
+        self._owner.recorded_ops.append(("data_changed", top.row(), bottom.row()))
+
+
+class _StubAbstractListModel:
+    """QAbstractListModel stand-in that records every row operation in
+    order to self.recorded_ops, so tests can assert on the exact diff."""
+
+    # Class-level attribute referenced elsewhere in the module body; not
+    # used by _apply_items but must exist so import doesn't blow up.
+    modelReset = MagicMock()
+
+    def __init__(self, *args, **kwargs):
+        self.recorded_ops = []
+        self.dataChanged = _RecordingDataChanged(self)
+
+    def beginRemoveRows(self, parent, first, last):
+        self.recorded_ops.append(("begin_remove", first, last))
+
+    def endRemoveRows(self):
+        self.recorded_ops.append(("end_remove",))
+
+    def beginInsertRows(self, parent, first, last):
+        self.recorded_ops.append(("begin_insert", first, last))
+
+    def endInsertRows(self):
+        self.recorded_ops.append(("end_insert",))
+
+    def beginMoveRows(self, source_parent, source_first, source_last,
+                      dest_parent, dest_child):
+        self.recorded_ops.append(
+            ("begin_move", source_first, source_last, dest_child)
+        )
+        return True
+
+    def endMoveRows(self):
+        self.recorded_ops.append(("end_move",))
+
+    def index(self, row, column=0, parent=None):
+        return _StubIndex(row)
+
+
+def _build_pyside_stubs():
+    """Construct PySide6 stub modules wired to the recording
+    QAbstractListModel above."""
+    pyside6 = types.ModuleType("PySide6")
+    qtcore = types.ModuleType("PySide6.QtCore")
+    qtgui = types.ModuleType("PySide6.QtGui")
+    qtwidgets = types.ModuleType("PySide6.QtWidgets")
+
+    qtcore.Qt = MagicMock()
+    qtcore.QEvent = MagicMock()
+    qtcore.QAbstractListModel = _StubAbstractListModel
+    qtcore.QModelIndex = lambda: _StubIndex(-1)
+    qtcore.QSize = MagicMock
+    qtcore.QRect = MagicMock
+    qtcore.Signal = MagicMock(return_value=MagicMock())
+    qtcore.QTimer = type(
+        "QTimer", (), {"singleShot": staticmethod(lambda delay_ms, callback: None)}
+    )
+
+    qtgui.QCursor = MagicMock()
+    qtgui.QIcon = MagicMock
+    qtgui.QColor = MagicMock
+    qtgui.QBrush = MagicMock
+    qtgui.QPen = MagicMock
+
+    qtwidgets.QDialog = type("QDialog", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QLineEdit = type("QLineEdit", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QListView = type("QListView", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QVBoxLayout = type("QVBoxLayout", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QStyledItemDelegate = type("QStyledItemDelegate", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QStyle = MagicMock()
+    qtwidgets.QMainWindow = type("QMainWindow", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QApplication = type(
+        "QApplication", (), {"instance": staticmethod(lambda: MagicMock())}
+    )
+
+    pyside6.QtCore = qtcore
+    pyside6.QtGui = qtgui
+    pyside6.QtWidgets = qtwidgets
+    return pyside6, qtcore, qtgui, qtwidgets
+
+
+def _load_core():
+    """Load tabtabtab_nuke_core under a fresh test-name spec, with stubs
+    swapped into sys.modules for the duration of the import only."""
+    pyside6, qtcore, qtgui, qtwidgets = _build_pyside_stubs()
+    stub_names = ["PySide6", "PySide6.QtCore", "PySide6.QtGui", "PySide6.QtWidgets"]
+    previous = {name: sys.modules.get(name) for name in stub_names}
+
+    sys.modules["PySide6"] = pyside6
+    sys.modules["PySide6.QtCore"] = qtcore
+    sys.modules["PySide6.QtGui"] = qtgui
+    sys.modules["PySide6.QtWidgets"] = qtwidgets
+    sys.modules.setdefault("PySide2", types.ModuleType("PySide2"))
+
+    core_path = os.path.join(os.path.dirname(__file__), "..", "tabtabtab_nuke_core.py")
+    spec = importlib.util.spec_from_file_location(
+        "tabtabtab_core_node_model_diff_test", core_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name in stub_names:
+            if previous[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous[name]
+    return module
+
+
+def _make_model(module, num_items=18, items=None):
+    """Construct a NodeModel without running its __init__ (which would
+    require a plugin and call update()). We only need the recording
+    base-class state plus the two fields _apply_items reads."""
+    model = module.NodeModel.__new__(module.NodeModel)
+    module.QtCore.QAbstractListModel.__init__(model)
+    model.num_items = num_items
+    model._items = list(items or [])
+    return model
+
+
+def _row(menupath, score=0, display_text=None, color=(None, None)):
+    """Build an item dict matching what NodeModel.update() synthesises."""
+    return {
+        "text": menupath,
+        "display_text": display_text or menupath,
+        "menupath": menupath,
+        "menuobj": object(),
+        "score": score,
+        "color": color,
+    }
+
+
+# --- tests --------------------------------------------------------------
+
+
+def test_no_change_emits_no_row_ops():
+    module = _load_core()
+    model = _make_model(module, items=[_row("A"), _row("B"), _row("C")])
+
+    model._apply_items([_row("A"), _row("B"), _row("C")])
+
+    assert model.recorded_ops == []
+    assert [i["menupath"] for i in model._items] == ["A", "B", "C"]
+
+
+def test_pure_insertion_into_empty_emits_inserts_in_order():
+    module = _load_core()
+    model = _make_model(module, items=[])
+
+    model._apply_items([_row("A"), _row("B"), _row("C")])
+
+    assert model.recorded_ops == [
+        ("begin_insert", 0, 0), ("end_insert",),
+        ("begin_insert", 1, 1), ("end_insert",),
+        ("begin_insert", 2, 2), ("end_insert",),
+    ]
+    assert [i["menupath"] for i in model._items] == ["A", "B", "C"]
+
+
+def test_pure_removal_walks_back_to_front():
+    """Removing back-to-front keeps each emitted index valid at the
+    moment Qt sees it; front-to-back would shift indices under us."""
+    module = _load_core()
+    model = _make_model(module, items=[_row("A"), _row("B"), _row("C")])
+
+    model._apply_items([])
+
+    assert model.recorded_ops == [
+        ("begin_remove", 2, 2), ("end_remove",),
+        ("begin_remove", 1, 1), ("end_remove",),
+        ("begin_remove", 0, 0), ("end_remove",),
+    ]
+    assert model._items == []
+
+
+def test_reorder_emits_moves_not_inserts_or_removes():
+    module = _load_core()
+    model = _make_model(module, items=[_row("A"), _row("B"), _row("C")])
+
+    model._apply_items([_row("C"), _row("A"), _row("B")])
+
+    op_kinds = [op[0] for op in model.recorded_ops]
+    assert "begin_remove" not in op_kinds
+    assert "begin_insert" not in op_kinds
+    assert "begin_move" in op_kinds
+    assert [i["menupath"] for i in model._items] == ["C", "A", "B"]
+
+
+def test_score_change_in_place_emits_data_changed_only():
+    module = _load_core()
+    model = _make_model(module, items=[_row("A", score=1), _row("B", score=1)])
+
+    model._apply_items([_row("A", score=1), _row("B", score=99)])
+
+    assert model.recorded_ops == [("data_changed", 1, 1)]
+    assert model._items[1]["score"] == 99
+
+
+def test_visually_identical_refresh_emits_nothing():
+    """When a refresh produces the same visible fields (display_text,
+    score, color) but new dict identity, _row_visually_equal must
+    suppress the dataChanged emission. Quiet refreshes are the whole
+    point of switching off modelReset — a repaint we don't need is a
+    repaint the user can see."""
+    module = _load_core()
+    model = _make_model(module, items=[_row("A", score=5)])
+
+    model._apply_items([_row("A", score=5)])
+
+    assert model.recorded_ops == []
+
+
+def test_mixed_remove_insert_and_reorder_orders_removes_first():
+    """Removes must precede inserts/moves so that beginInsert/Move
+    indices are interpreted against a list whose stale rows are gone."""
+    module = _load_core()
+    model = _make_model(
+        module, items=[_row("A"), _row("B"), _row("C"), _row("D")]
+    )
+
+    # Old: A B C D. New: D A E. (B and C removed, E inserted, D moved up.)
+    model._apply_items([_row("D"), _row("A"), _row("E")])
+
+    assert [i["menupath"] for i in model._items] == ["D", "A", "E"]
+
+    op_kinds = [op[0] for op in model.recorded_ops]
+    last_remove = max(
+        (i for i, kind in enumerate(op_kinds) if kind == "begin_remove"),
+        default=-1,
+    )
+    first_struct_after_remove = next(
+        (i for i, kind in enumerate(op_kinds)
+         if kind in ("begin_insert", "begin_move")),
+        len(op_kinds),
+    )
+    assert last_remove < first_struct_after_remove
+
+
+def test_off_window_churn_is_silent():
+    """Items past num_items aren't visible to Qt (rowCount caps), so
+    swapping them emits no row operations."""
+    module = _load_core()
+    items = [_row(letter) for letter in "ABCDE"]
+    model = _make_model(module, num_items=3, items=items)
+
+    # Visible window unchanged (A, B, C); off-window swapped D,E -> F,G.
+    model._apply_items([_row("A"), _row("B"), _row("C"), _row("F"), _row("G")])
+
+    assert model.recorded_ops == []
+    assert [i["menupath"] for i in model._items] == ["A", "B", "C", "F", "G"]
+
+
+def test_off_window_item_promoted_into_window_emits_structural_ops():
+    """When something previously off-window enters the visible window,
+    that crossing must surface — otherwise the user wouldn't see the
+    new top-of-list item appear."""
+    module = _load_core()
+    items = [_row(letter) for letter in "ABCDE"]
+    model = _make_model(module, num_items=3, items=items)
+
+    # E was off-window (position 4); now it's at position 0.
+    # Visible window must shift from [A, B, C] to [E, A, B].
+    model._apply_items([_row("E"), _row("A"), _row("B"), _row("C"), _row("D")])
+
+    op_kinds = [op[0] for op in model.recorded_ops]
+    assert "begin_insert" in op_kinds  # E entering the window
+    assert "begin_remove" in op_kinds  # C leaving the window
+    assert [i["menupath"] for i in model._items[:3]] == ["E", "A", "B"]


### PR DESCRIPTION
## Summary

Two-part fix for the popup-show lag introduced by the deferred two-stage refresh in #6/#7.

- **`NodeModel` now emits row ops instead of `modelReset`.** `update()` calls a new `_apply_items` that diffs the visible window keyed on `menupath` and emits `beginRemoveRows`/`endRemoveRows`, `beginInsertRows`/`endInsertRows`, `beginMoveRows`/`endMoveRows`, and `dataChanged` for in-place changes. Off-window items (past `num_items`) are swapped silently since `rowCount` caps there. Visually-identical refreshes emit nothing — `_row_visually_equal` compares only the fields the delegate paints (`display_text`, `score`, `color`).

- **`show()` runs the cheap refresh synchronously.** `weights.load()` + `plugin.get_items()` against a warm cache is sub-ms; the 100–400ms cost that motivated the original deferral lives in `invalidate_cache()` + full re-walk, which is still deferred via `QTimer.singleShot(0, _refresh_fresh)`. The popup now paints with current items already present — no empty-state flash between `show()` and the first tick. Combined with row ops, the second tick is visually quiet too.

## Why

Issue: the deferred refresh fixed input loss (#3) and bounded staleness (#6) but introduced an unacceptable perceived lag — the popup appeared empty until the first `QTimer` tick, then `modelReset` flashed it again on the second tick. Users saw a blank-and-rebuild on every open.

Why this fix doesn't regress prior issues:
- **Input loss (#3)**: the cheap path is fast against a warm cache; the expensive `_refresh_fresh` is still deferred. If the cache is cold, the synchronous pass might be slower — worth measuring on first open after a Nuke restart.
- **Staleness (#6)**: `_refresh_fresh` still runs one tick later, so staleness is still bounded to a single event-loop tick.
- **Selection clearing**: `modelReset` cleared the QListView selection; row ops preserve it. The explicit `move_selection(where="first")` calls remain — they're now no-ops in the common case but keep the "after refresh, jump to top match" behaviour intact.

## Compatibility with downstream forks

The change lives in `tabtabtab_nuke_core.py`, which is the app-agnostic core; no `nuke` import is touched. The diff keys on `menupath`, which is part of the documented `TabTabTabPlugin.get_items` contract. `NodeModel` no longer emits `modelReset` during normal updates — downstream forks that connected listeners to that signal would silently stop receiving them. Standard `QListView` consumers handle row ops natively and are unaffected.

## Test plan

- [x] Existing 15 tests pass (`tests/test_main_window_discovery.py`, `tests/test_monitor_selection.py`).
- [x] New `tests/test_node_model_diff.py` (9 tests) locks the diff behaviour: no-op, pure insert, pure remove (back-to-front), reorder-as-moves, in-place data change, quiet refresh, mixed-ops ordering invariant (removes precede inserts/moves), and `num_items` window edge cases.
- [ ] Manual: open popup in Nuke, verify items are visible the instant the popup paints (no blank flash).
- [ ] Manual: verify selection stays on row 0 across the deferred `_refresh_fresh` tick.
- [ ] Manual: verify input loss stays fixed — type immediately on popup open, no characters lost.
- [ ] Manual: verify cold-cache first open (after Nuke restart) still feels responsive.