### PR TITLE
perf: fix first-invocation hitch (issue #11)

### DIFF
--- a/tabtabtab_nuke.py
+++ b/tabtabtab_nuke.py
@@ -27,30 +27,28 @@ def _extract_node_class_from_script(script_text):
     return None
 
 
-def _menu_fingerprint(menu, depth=2):
-    """Cheap fingerprint of a Nuke menu using only item names.
+def _menu_fingerprint(menu):
+    """Full-depth fingerprint of a Nuke menu using only item names.
 
     Used to detect whether a full re-walk via _find_nuke_menu_items is
-    needed. Calling .name() on items is essentially free; .script() and
-    .shortcut() (the expensive calls) are deliberately avoided here.
+    needed. Calling .name() on items and .items() on submenus are the
+    cheap calls; .script() and .shortcut() (the expensive ones done by
+    _find_nuke_menu_items) are deliberately avoided here, so this stays
+    far cheaper than a full walk even while recursing the whole tree.
 
-    Recurses `depth` levels so common gizmo / menu installs are detected
-    without paying for a full traversal. Deep additions buried below the
-    fingerprint depth (e.g. a new ToolSet several levels in) are missed
-    by this fast-path check, but the belt-and-suspenders refresh in
-    TabTabTabWidget._refresh_after_close calls invalidate_cache() on
-    every popup close, so deep changes are still picked up — at most
-    one stale popup behind any given mid-session change.
+    Recurses every level rather than a bounded depth: get_items() compares
+    this fingerprint to decide whether to re-walk, and TabTabTabWidget no
+    longer forces an unconditional re-walk on every open. A shallow
+    fingerprint would let a deep mid-session install (e.g. a new ToolSet
+    several levels in) slip past unnoticed; sampling every level keeps the
+    cache trustworthy without paying the expensive per-leaf reads.
     """
     parts = []
     try:
         for item in menu.items():
             name = item.name()
             if isinstance(item, nuke.Menu):
-                if depth > 1:
-                    parts.append(("M", name, _menu_fingerprint(item, depth - 1)))
-                else:
-                    parts.append(("M", name))
+                parts.append(("M", name, _menu_fingerprint(item)))
             else:
                 parts.append(("I", name))
     except Exception:
@@ -132,17 +130,18 @@ class NukePlugin(TabTabTabPlugin):
         """Return all menu items, using a cached result if menus haven't
         changed since the last walk.
 
-        Walks both Nodes and Nuke menus only when a cheap fingerprint of
-        those menus differs from the last walk, or when invalidate_cache()
-        has been called. The expensive part of the walk is the .script()
-        and .shortcut() calls inside _find_nuke_menu_items; the fingerprint
-        avoids them entirely so the staleness check is essentially free.
+        Walks both Nodes and Nuke menus only when a fingerprint of those
+        menus differs from the last walk, or when invalidate_cache() has
+        been called. The expensive part of the walk is the .script() and
+        .shortcut() calls inside _find_nuke_menu_items; the fingerprint
+        reads only item names (and submenu structure), so the staleness
+        check is cheap relative to a real walk.
 
-        Belt-and-suspenders against fingerprint blind spots: TabTabTabWidget
-        runs a second deferred refresh on every open that calls
-        invalidate_cache() and re-walks, so deeply nested menu changes
-        that the shallow fingerprint can't sample are picked up within
-        the same open (after a brief render of the cached data).
+        The fingerprint recurses the full menu tree, so even deeply nested
+        mid-session installs (a ToolSet several levels in) change it and
+        trigger a re-walk. TabTabTabWidget therefore no longer forces an
+        unconditional re-walk on every open — it trusts this check — which
+        is what removes the per-open .script()/.shortcut() cost.
         """
         fingerprint = (
             _menu_fingerprint(nuke.menu("Nodes")),
@@ -166,20 +165,29 @@ class NukePlugin(TabTabTabPlugin):
         # Menu set changed (or first walk) — drop colour cache too in case
         # new node classes appeared. Independent invalidation of the colour
         # cache for default-colour preference edits happens via
-        # invalidate_cache() called from TabTabTabWidget._refresh_fresh.
+        # invalidate_color_cache() called from TabTabTabWidget._refresh_fresh.
         self._color_cache = {}
         return all_items
 
     def invalidate_cache(self):
         """Drop the items + fingerprint cache and the per-class colour
-        cache. Called by TabTabTabWidget._refresh_fresh on the second
-        deferred tick of every open so the get_items() that follows
-        walks fresh data, regardless of whether the shallow menu
-        fingerprint would have caught the change. Also clears colour
-        memoisation so default-node-colour preference edits show up on
-        the same open they were made on."""
+        cache, forcing the next get_items() to walk fresh. No longer
+        called on every open: the full-depth menu fingerprint makes
+        get_items()'s own change detection reliable, so the popup relies
+        on that instead of an unconditional re-walk. Retained as an
+        explicit full-invalidation extension point."""
         self._cached_items = None
         self._cached_menu_fingerprint = None
+        self._color_cache = {}
+
+    def invalidate_color_cache(self):
+        """Drop only the per-class colour memoisation, leaving the items +
+        fingerprint cache intact. Called by TabTabTabWidget._refresh_fresh
+        on every open's second deferred tick so default-node-colour
+        preference edits — which don't change menu structure and so don't
+        trip the fingerprint — surface on the open they were made, without
+        forcing the expensive item re-walk. Cheap now that colour is
+        resolved only for the visible window."""
         self._color_cache = {}
 
     def get_weights_file(self):

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -394,8 +394,7 @@ class NodeModel(QtCore.QAbstractListModel):
                     'display_text': display_text,
                     'menupath': n['menupath'],
                     'menuobj': n['menuobj'],
-                    'score': score,
-                    'color': self._color_fn(n['menuobj'])})
+                    'score': score})
 
             elif not force_consecutive and nonconsec_find(filtertext, search_string, anchored):
                 # Matches, get weighting and add to list of stuff
@@ -406,15 +405,25 @@ class NodeModel(QtCore.QAbstractListModel):
                     'display_text': display_text,
                     'menupath': n['menupath'],
                     'menuobj': n['menuobj'],
-                    'score': score,
-                    'color': self._color_fn(n['menuobj'])})
+                    'score': score})
 
         # Sort based on scores (descending), then alphabetically
         sort_a = sorted(scored_a, key=lambda k: (-k['score'], k['text']))
         sort_b = sorted(scored_b, key=lambda k: (-k['score'], k['text']))
         s = sort_a + sort_b
 
-        self._apply_items(s)
+        # Resolve colour only for the rows that will actually be shown.
+        # Colour plays no part in scoring or sorting, and only the first
+        # num_items rows are ever painted. Computing it for every candidate
+        # meant a nuke.defaultNodeColor() call per matched item — the entire
+        # menu set when the filter is empty, which is exactly the first-
+        # invocation state. Cap first, then colour the survivors so the cost
+        # is O(num_items) per update instead of O(matches).
+        visible = s[:self.num_items]
+        for item in visible:
+            item['color'] = self._color_fn(item['menuobj'])
+
+        self._apply_items(visible)
 
     def _apply_items(self, new_items):
         """Replace visible items via minimal row operations instead of a

--- a/tabtabtab_nuke_core.py
+++ b/tabtabtab_nuke_core.py
@@ -67,12 +67,25 @@ class TabTabTabPlugin:
         return (None, None)
 
     def invalidate_cache(self):
-        """Optional hook called after the popup closes so the next get_items()
-        and get_color() return fresh data.
+        """Optional hook to drop ALL plugin-side caches so the next
+        get_items() and get_color() return fully fresh data.
 
         Override to drop any plugin-side caches (e.g., a recursive menu walk
         or per-class colour memoisation). Default is a no-op for plugins that
-        don't cache.
+        don't cache. No longer called on every open — get_items() is trusted
+        to re-walk on its own when its change-detection (e.g. a menu
+        fingerprint) fires. See invalidate_color_cache for the per-open hook.
+        """
+        pass
+
+    def invalidate_color_cache(self):
+        """Optional hook called on each open's second deferred tick to drop
+        only colour memoisation — not the (expensive) item walk cache.
+
+        Lets host-side default-colour / preference edits, which don't change
+        menu structure and so wouldn't trip get_items()'s change detection,
+        surface on the open they were made without forcing a full re-walk.
+        Default is a no-op for plugins that don't cache colour.
         """
         pass
 
@@ -874,14 +887,22 @@ class TabTabTabWidget(QtWidgets.QDialog):
         QtCore.QTimer.singleShot(0, self._refresh_fresh)
 
     def _refresh_fresh(self):
-        """Expensive refresh: force a full re-walk of the plugin's items,
-        bypassing whatever cache the cheap path used.
+        """Second deferred tick: drop the plugin's colour memoisation and
+        re-render, so host-side colour / preference edits that leave menu
+        structure unchanged surface on the open they were made.
 
-        Runs one tick after _refresh_after_show. Bounds staleness to a
-        brief moment after open instead of an entire open/close cycle,
-        at the cost of a possible slight typing hitch while the walk
-        runs. No-op if the user already closed the popup before this
-        fires — the next open will repeat the same two-stage refresh.
+        Runs one tick after _refresh_after_show. Unlike the previous
+        design it does NOT force a full item re-walk: get_items() re-walks
+        on its own only when its change detection (a full-depth menu
+        fingerprint) differs, so an unchanged menu set — the common case —
+        reuses the preloaded cache instead of paying the 100-400ms
+        .script()/.shortcut() walk on every single open. That forced walk
+        was a first-invocation cost in issue #11. Colour is resolved
+        lazily for the visible window now, so clearing its cache here is
+        cheap.
+
+        No-op if the user already closed the popup before this fires —
+        the next open will repeat the same two-stage refresh.
 
         NodeModel emits row ops rather than modelReset, so this pass is
         visually quiet when nothing changed: only rows that genuinely
@@ -889,7 +910,7 @@ class TabTabTabWidget(QtWidgets.QDialog):
         """
         if not self.isVisible():
             return
-        self.plugin.invalidate_cache()
+        self.plugin.invalidate_color_cache()
         self.things_model.refresh_items(self.plugin.get_items())
         self.move_selection(where="first")
 

--- a/tests/test_menu_fingerprint.py
+++ b/tests/test_menu_fingerprint.py
@@ -1,0 +1,202 @@
+"""Tests for the Nuke menu fingerprint and the split between full
+cache invalidation and colour-only invalidation.
+
+Covers:
+  - _menu_fingerprint recurses the full tree, so a deep change (below the
+    old depth-2 bound) produces a different fingerprint. This is what lets
+    TabTabTabWidget drop the unconditional per-open re-walk and still catch
+    deep mid-session menu installs (issue #11).
+  - NukePlugin.invalidate_color_cache clears only colour memoisation,
+    leaving the item + fingerprint cache intact (so an unchanged menu set
+    is not re-walked on every open).
+  - NukePlugin.invalidate_cache still clears everything.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class _FakeMenuItem:
+    """Leaf menu item: only .name() is read by _menu_fingerprint."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeMenu(_FakeMenuItem):
+    """Submenu: exposes .items(). Subclasses _FakeMenuItem so leaves are
+    not instances of the Menu type (matching Nuke's class hierarchy as
+    far as the isinstance check in _menu_fingerprint cares)."""
+
+    def __init__(self, name, children):
+        super().__init__(name)
+        self._children = children
+
+    def items(self):
+        return self._children
+
+
+def _build_pyside_stubs():
+    pyside6 = types.ModuleType("PySide6")
+    qtcore = types.ModuleType("PySide6.QtCore")
+    qtgui = types.ModuleType("PySide6.QtGui")
+    qtwidgets = types.ModuleType("PySide6.QtWidgets")
+
+    qtcore.Qt = MagicMock()
+    qtcore.QEvent = MagicMock()
+    qtcore.QAbstractListModel = type("QAbstractListModel", (), {
+        "__init__": lambda self, *a, **k: None,
+        "modelReset": MagicMock(),
+    })
+    qtcore.QModelIndex = MagicMock
+    qtcore.QSize = MagicMock
+    qtcore.QRect = MagicMock
+    qtcore.Signal = MagicMock(return_value=MagicMock())
+    qtcore.QTimer = type(
+        "QTimer", (), {"singleShot": staticmethod(lambda delay_ms, cb: None)}
+    )
+
+    qtgui.QCursor = MagicMock()
+    qtgui.QIcon = MagicMock
+    qtgui.QColor = MagicMock
+    qtgui.QBrush = MagicMock
+    qtgui.QPen = MagicMock
+
+    qtwidgets.QDialog = type("QDialog", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QLineEdit = type("QLineEdit", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QListView = type("QListView", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QVBoxLayout = type("QVBoxLayout", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QStyledItemDelegate = type("QStyledItemDelegate", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QStyle = MagicMock()
+    qtwidgets.QMainWindow = type("QMainWindow", (), {"__init__": lambda self, *a, **k: None})
+    qtwidgets.QApplication = type(
+        "QApplication", (), {"instance": staticmethod(lambda: MagicMock())}
+    )
+
+    pyside6.QtCore = qtcore
+    pyside6.QtGui = qtgui
+    pyside6.QtWidgets = qtwidgets
+    return pyside6
+
+
+def _build_nuke_stub():
+    nuke = types.ModuleType("nuke")
+    nuke.Menu = _FakeMenu
+    nuke.MenuItem = _FakeMenuItem
+    nuke.NUKE_VERSION_MAJOR = 15
+    nuke.menu = lambda name: None
+    nuke.defaultNodeColor = lambda cls: 0
+    nuke.pluginPath = lambda: []
+    return nuke
+
+
+def _load_nuke_plugin():
+    """Load tabtabtab_nuke under a fresh test-name spec with nuke + PySide
+    stubbed for the duration of the import only."""
+    pyside6 = _build_pyside_stubs()
+    nuke_stub = _build_nuke_stub()
+
+    stub_modules = {
+        "PySide6": pyside6,
+        "PySide6.QtCore": pyside6.QtCore,
+        "PySide6.QtGui": pyside6.QtGui,
+        "PySide6.QtWidgets": pyside6.QtWidgets,
+        "nuke": nuke_stub,
+    }
+    previous = {name: sys.modules.get(name) for name in stub_modules}
+
+    sys.modules.update(stub_modules)
+    sys.modules.setdefault("PySide2", types.ModuleType("PySide2"))
+    # tabtabtab_nuke does `from tabtabtab_nuke_core import ...`; make sure a
+    # stale copy from another test's stubbed import isn't reused.
+    sys.modules.pop("tabtabtab_nuke_core", None)
+
+    repo_root = os.path.join(os.path.dirname(__file__), "..")
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
+    plugin_path = os.path.join(repo_root, "tabtabtab_nuke.py")
+    spec = importlib.util.spec_from_file_location(
+        "tabtabtab_nuke_fingerprint_test", plugin_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in previous.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+        sys.modules.pop("tabtabtab_nuke_core", None)
+    return module
+
+
+# --- tests --------------------------------------------------------------
+
+
+def _deep_tree(leaf_name):
+    """Three levels deep: Root > Mid > Inner > <leaf_name>. The leaf sits
+    below the old depth-2 fingerprint bound."""
+    return _FakeMenu("Root", [
+        _FakeMenu("Mid", [
+            _FakeMenu("Inner", [
+                _FakeMenuItem(leaf_name),
+            ]),
+        ]),
+    ])
+
+
+def test_fingerprint_detects_deep_change():
+    module = _load_nuke_plugin()
+
+    fp_before = module._menu_fingerprint(_deep_tree("Blur"))
+    fp_after = module._menu_fingerprint(_deep_tree("Defocus"))
+
+    assert fp_before is not None
+    assert fp_before != fp_after
+
+
+def test_fingerprint_stable_for_identical_trees():
+    module = _load_nuke_plugin()
+
+    assert (
+        module._menu_fingerprint(_deep_tree("Blur"))
+        == module._menu_fingerprint(_deep_tree("Blur"))
+    )
+
+
+def test_invalidate_color_cache_keeps_item_cache():
+    module = _load_nuke_plugin()
+    plugin = module.NukePlugin()
+
+    plugin._cached_items = [{"menupath": "Cat/Node"}]
+    plugin._cached_menu_fingerprint = ("fp",)
+    plugin._color_cache = {"Blur": ("c", "c")}
+
+    plugin.invalidate_color_cache()
+
+    assert plugin._color_cache == {}
+    assert plugin._cached_items == [{"menupath": "Cat/Node"}]
+    assert plugin._cached_menu_fingerprint == ("fp",)
+
+
+def test_invalidate_cache_clears_everything():
+    module = _load_nuke_plugin()
+    plugin = module.NukePlugin()
+
+    plugin._cached_items = [{"menupath": "Cat/Node"}]
+    plugin._cached_menu_fingerprint = ("fp",)
+    plugin._color_cache = {"Blur": ("c", "c")}
+
+    plugin.invalidate_cache()
+
+    assert plugin._color_cache == {}
+    assert plugin._cached_items is None
+    assert plugin._cached_menu_fingerprint is None

--- a/tests/test_node_model_diff.py
+++ b/tests/test_node_model_diff.py
@@ -177,6 +177,40 @@ def _row(menupath, score=0, display_text=None, color=(None, None)):
     }
 
 
+class _CountingColorFn:
+    """color_fn stand-in that records how many times it was invoked, so
+    tests can assert colour is resolved only for the visible window."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, menuobj):
+        self.calls += 1
+        return (None, None)
+
+
+def _make_filtering_model(module, all_items, num_items=18, filtertext="",
+                          color_fn=None):
+    """Construct a NodeModel without __init__, wired with just enough
+    state to exercise update() (filter + score + colour resolution)."""
+    model = module.NodeModel.__new__(module.NodeModel)
+    module.QtCore.QAbstractListModel.__init__(model)
+    model.num_items = num_items
+    model._all = all_items
+    model._filtertext = filtertext
+    model._icon_fn = lambda obj: None
+    model._color_fn = color_fn if color_fn is not None else (lambda obj: (None, None))
+    model._space_mode_order = list(module.DEFAULT_SPACE_MODE_ORDER)
+    model._items = []
+    model.weights = types.SimpleNamespace(get=lambda menupath, default=0: 0)
+    return model
+
+
+def _menu_item(menupath):
+    """A get_items()-shaped entry: only the fields update() reads."""
+    return {"menupath": menupath, "menuobj": object()}
+
+
 # --- tests --------------------------------------------------------------
 
 
@@ -317,6 +351,46 @@ def test_pre_existing_off_window_items_are_trimmed_silently():
 
     assert model.recorded_ops == []
     assert [i["menupath"] for i in model._items] == ["A", "B", "C"]
+
+
+def test_update_resolves_colour_only_for_visible_window():
+    """With an empty filter every item matches (the first-invocation
+    state), but only num_items rows are painted. update() must call
+    color_fn at most num_items times, not once per matched candidate —
+    that eager per-candidate colour loop was the first-invocation hitch
+    (issue #11)."""
+    module = _load_core()
+    counter = _CountingColorFn()
+    all_items = [_menu_item("Cat/Node%02d" % i) for i in range(50)]
+    model = _make_filtering_model(
+        module, all_items, num_items=18, filtertext="", color_fn=counter
+    )
+
+    model.update()
+
+    assert len(model._items) == 18
+    assert counter.calls == 18
+    assert all(item["color"] == (None, None) for item in model._items)
+
+
+def test_update_colours_every_match_when_fewer_than_window():
+    """When the match count is below num_items, colour is resolved for
+    exactly the matched rows — never more than were shown."""
+    module = _load_core()
+    counter = _CountingColorFn()
+    all_items = [
+        _menu_item("Cat/Apple"),
+        _menu_item("Cat/Avocado"),
+        _menu_item("Cat/Banana"),
+    ]
+    model = _make_filtering_model(
+        module, all_items, num_items=18, filtertext="a", color_fn=counter
+    )
+
+    model.update()
+
+    assert counter.calls == len(model._items)
+    assert counter.calls <= 18
 
 
 def test_self_items_consistent_at_end_of_each_pair():


### PR DESCRIPTION
Fixes #11 — the palette hitches on Tab, worst on the first invocation of a session.

## Root cause

Two GUI-thread costs land together on the first open, and the existing preload/fingerprint/row-op machinery targeted neither:

1. **Eager colour resolution across every candidate.** `NodeModel.update()` called `color_fn` (`nuke.defaultNodeColor`) for *every matched item* before sorting and capping to `num_items`. Colour is never used for scoring — only the ≤18 visible rows are painted. On the first invocation the input box is empty, so **every** menu item matches and colour was resolved for the entire menu set (hundreds–thousands of host API calls) to show 18 rows. This is exactly why the hitch is "at least on first invocation": every later open pre-fills a narrow filter.

2. **An unconditional forced full re-walk on every open.** `_refresh_fresh` ran `invalidate_cache()` + `get_items()`, re-walking with `.script()`/`.shortcut()` per item (~100–400ms) on every open regardless of the fingerprint cache — and on first open could stack with the first tick's walk. It also wiped the colour cache mid-open, so cost (1) couldn't amortize.

## Fixes (one commit each)

- **Resolve colour only for the visible window.** Cap the sorted list to `num_items` first, then resolve colour for those survivors — O(num_items) per update instead of O(matches). Icons were already lazy; colour now matches.
- **Stop forcing a per-open re-walk.** The forced walk only existed to catch deep menu changes the shallow depth-2 fingerprint missed. `_menu_fingerprint` now recurses the full tree (names only — still far cheaper than a real walk), so `get_items()`'s own change detection reliably catches deep installs and the popup trusts it: an unchanged menu set reuses the preloaded cache and pays no walk on open. Colour/preference edits (which don't change menu structure) are handled by a new lightweight `invalidate_color_cache()` hook called each open — cheap now that colour is lazy.

## Alternatives considered

- *Preload harder/earlier* — already done; doesn't touch the per-open refresh that re-walks and recolours regardless.
- *Background-thread the walk/colour* — Nuke's menu API and the Qt model are main-thread-only; unsafe.
- *Cache colour permanently* — reintroduces staleness on default-colour preference edits; the lazy-visible approach is fast and fresh.
- *Drop `_refresh_fresh` entirely* — loses the deep-change safety net; the deeper fingerprint keeps it while removing the cost.

## Tests

`pytest tests/` → 31 passed (was 25). New coverage:
- colour resolved at most `num_items` times for a broad/empty filter, and exactly per-match below the window;
- full-depth fingerprint detects a change below the old depth-2 bound;
- `invalidate_color_cache` clears only colour; `invalidate_cache` clears everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)